### PR TITLE
Merge branch 'tom/mgn-fix-magin-preview-step2-style' into tom/mgn-enable-try-magin

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -7,7 +7,7 @@ Fixes #<issue number>
 # Commit Message Format
 # ────────────────────────────────────────── 100 chars ────────────────────────────────────────────┤
 #
-# <reason>          feat | enhance | fix | refactor | perf | style | BREAKING-CHANGE
+# <reason>          feat | enhance | fix | refactor | chore | perf | style | BREAKING-CHANGE
 # <topic>           build | ci | docs | refactor | test | name of file, component, feature, etc
 # <instruction>     what to do, writen as if giving command or instruction
 # <motivation>      what's the reason for the change, provide context

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,8 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
+if [ "$branch" = "main" ]; then
+  echo "You can't commit directly to main branch"
+  exit 1
+fi
 yarn lint-staged

--- a/.husky/pre-merge-commit
+++ b/.husky/pre-merge-commit
@@ -1,5 +1,14 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-yarn build:ssg
+FILES=( ".eslint*" ".linkstagerc.js" )
+FILES+=( "additional.js" "next.config.js" "next-env.d.ts" "package.json" "tailwind.config.js" "tsconfig/*" "tsconfig*" "yarn.lock")
+if [ git diff --cached --quiet -- $FILES ]; then
+  yarn build:ssg
+fi
+
+if [ git diff --cached --quiet -- Dockerfile ]; then
+  yarn docker:rebuild
+fi
+
 yarn test

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,6 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn build:ssg
+if [ "$branch" = "main" ]; then
+  yarn build:ssg
+fi

--- a/ci/cloudbuild.gcr.yaml
+++ b/ci/cloudbuild.gcr.yaml
@@ -24,6 +24,7 @@ steps:
   # 2. Build docker
   - name: 'gcr.io/cloud-builders/docker'
     args: ['build', '-t', '${_IMAGE_NAME}', '--cache-from', '${_IMAGE_NAME}:latest', './docker']
+    env: ['NEXT_PUBLIC_ANALYTICS_ID=${_ENV_NEXT_PUBLIC_ANALYTICS_ID}']
 
   # 3. Push container to registery
   - name: 'gcr.io/cloud-builders/docker'

--- a/ci/trigger-mgn-concept--gcr--cdp.yaml
+++ b/ci/trigger-mgn-concept--gcr--cdp.yaml
@@ -15,3 +15,4 @@ substitutions:
   _REGION: us-central1
   _SERVICE_NAME: mgn-concept
   _TRAFFIC_TO_LATEST: 'false'
+  _ENV_NEXT_PUBLIC_ANALYTICS_ID: ''

--- a/ci/trigger-mgn-concept--gcr--pr.yaml
+++ b/ci/trigger-mgn-concept--gcr--pr.yaml
@@ -16,3 +16,4 @@ substitutions:
   _REGION: us-central1
   _SERVICE_NAME: mgn-concept
   _TRAFFIC_TO_LATEST: 'false'
+  _ENV_NEXT_PUBLIC_ANALYTICS_ID: ''

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -7,8 +7,7 @@ import IconGithub from '@/assets/common/icons/github-mark.svg';
 export default function Home() {
   const router = useRouter();
   // REFACTOR: load value from json file
-  const featureFlagOnClick = false;
-
+  const featureFlagOnClick = true;
 
   return (
     <div className='flex flex-column h-screen v-screen justify-content-center align-items-center'>

--- a/src/pages/try-magin/1/index.tsx
+++ b/src/pages/try-magin/1/index.tsx
@@ -20,7 +20,7 @@ export default function MarginPreview() {
             <div className='mgn-guide-step1 flex flex-column h-full justify-items-center'>
               <div className='flex h-full'>
                 <GuideMessage className='flex flex-column h-3/4 justify-content-end'>
-                  <h2>
+                  <h2 className='text-black'>
                     {locale.guide.step1_maginPresents}
                     <br />
                     {locale.book.title}

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -36,6 +36,12 @@ $mgn-text-sizes: (
   @return map-get($mgn-text-sizes, $name);
 }
 
+// -------------------------------
+// Text colours
+// @function mgn-text($name) {
+//   @return map-get($mgn-colors, 'color: $name');
+// }
+
 $mgn-text-p: black;
 $mgn-text-heading: black;
 // TODO: $mgn-text-cta-primary: mgn-color('blue-rb');


### PR DESCRIPTION
# What

- enhance | css: add utility classes for mgn colors
- enhance | ci: set NEXT_PUBLIC_ANALYTICS_ID based on gcp var
- enhance | huksy: run docker:rebuild on merge-commit if Dockerfile changed
- enhance | huksy: run build:ssg on merge-commit if build files changed
- enhance | husky: prevent commit directly to main
- enhance | husky: run builg:ssg if pushing to main branch
- enhance | gitmessage: add chore as a valid reason
- fix | MaginPreview: change message to black
- enhance | Home: enable try magin button


# Why


# Checklist

[n/a] I have added enough test cases
[✓] I have self-reviewed the changes and have added explanatory comments as needed
