### PR TITLE
fix | ci: load next public env during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ RUN yarn install --production
 # Stage: Builder using SSG (server-side generated)
 FROM node:16-alpine AS builder-ssg
 
+ARG NODE_ENV NEXT_PUBLIC_ANALYTICS_ID NEXT_PUBLIC_STRIPE_PAYMENT_URL
+
 WORKDIR /usr/src/app
 COPY --from=deps-builder /usr/src/app/node_modules ./node_modules
 COPY additional.d.ts jest.config.js next.config.js next-env.d.ts package.json \

--- a/ci/cloudbuild.gcr.yaml
+++ b/ci/cloudbuild.gcr.yaml
@@ -24,7 +24,19 @@ steps:
   # 2. Build docker
   # OPTIMIZE: research if there's a better way to load all env variables
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['build', '-t', '${_IMAGE_NAME}', '--cache-from', '${_IMAGE_NAME}:latest', './docker']
+    args:
+      [
+        'build',
+        '-t',
+        '${_IMAGE_NAME}',
+        '--cache-from',
+        '${_IMAGE_NAME}:latest',
+        './docker',
+        '--build-arg',
+        'NEXT_PUBLIC_ANALYTICS_ID',
+        '--build-arg',
+        'NEXT_PUBLIC_STRIPE_PAYMENT_URL',
+      ]
     env:
       [
         'NEXT_PUBLIC_ANALYTICS_ID=${_ENV_NEXT_PUBLIC_ANALYTICS_ID}',

--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,7 @@ module.exports = {
   images: { unoptimized: true }, // OPTIMIZE: disable when we switch to running server
   reactStrictMode: true,
   swcMinify: true, // use swc instead of terser for minification
+  // output: 'standalone', // TODO: determine what affect this has, if I should turn it on for docker builds
   trailingSlash: true, // allow url ending with traling slash
   typescript: { tsconfigPath: './tsconfig.dev-next.json' },
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "prettier": "prettier --write --ignore-unknown",
     "prettier:check": "prettier --check --ignore-unknown",
     "docker:clean": "rimraf docker",
-    "docker:build": "docker build -t mgn-app docker --target runner-ssg",
+    "docker:build": "docker build -t mgn-app docker --target runner-ssg --build-arg NEXT_PUBLIC_ANALYTICS_ID --build-arg NEXT_PUBLIC_STRIPE_PAYMENT_URL",
     "docker:build:prod": "docker build -t mgn-app docker --target runner-ssg",
     "docker:build-run": "yarn docker:build && yarn docker:run",
     "docker:run": "docker run -d -p 8080:8080 mgn-app",


### PR DESCRIPTION
# What

fix | ci: load next public env during build


# Checklist

[too early ] I have added enough test cases
[✔︎] I have self-reviewed the changes and have added explanatory comments as needed
