### PR TITLE
enhance | tom/mgn-72 see final design and copy for joining

### DIFF
--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -2,23 +2,35 @@
 // All rights reserved.
 import { Button } from 'primereact/button';
 
+// REFACTOR: accept enums  for className and translate to proper css class
 interface Props {
-  left: { label: string; onClick: () => void };
-  right: { label: string; onClick: () => void };
+  left?: { className: string; label: string; onClick: () => void };
+  middle?: { className: string; label: string; onClick: () => void };
+  right?: { className: string; label: string; onClick: () => void };
   className?: string;
 }
 
 export default function Navigation(props: Props) {
-  const { left, right, className = '' } = props;
+  const { left = null, middle = null, right = null, className = 'justify-content-between' } = props;
 
+  // OPTIMIZE: generalize to accept any # of objects
   return (
-    <div className={`mgn-navigation flex justify-content-between ${className}`}>
-      <Button className='text-center mgn-cta-secondary' onClick={left.onClick}>
-        {left.label}
-      </Button>
-      <Button className='text-center mgn-cta-primary' onClick={right.onClick}>
-        {right.label}
-      </Button>
+    <div className={`mgn-navigation flex ${className}`}>
+      {left && (
+        <Button className={`text-center ${left.className}`} onClick={left.onClick}>
+          {left.label}
+        </Button>
+      )}
+      {middle && (
+        <Button className={`text-center ${middle.className}`} onClick={middle.onClick}>
+          {middle.label}
+        </Button>
+      )}
+      {right && (
+        <Button className={`text-center ${right.className}`} onClick={right.onClick}>
+          {right.label}
+        </Button>
+      )}
     </div>
   );
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -8,6 +8,10 @@
     "prev": "Previous Scene",
     "next": "Next Scene"
   },
+  "general": {
+    "magin": "magin",
+    "comingSoon": "coming soon"
+  },
   "guide": {
     "step1_maginPresents": "magin presents",
     "step1_watchNovel": "Watch Novel",
@@ -20,11 +24,16 @@
   },
   "join": {
     "step1_wantMore": "Want to see more",
-    "step1_shapeItsFuture": "Join and shape its future",
-    "step1_whatYouGet": "What you get",
-    "step1_whatYouGet1": "Free updates for the next 2 years",
-    "step1_whatYouGet2": "No recurring subscription",
-    "step1_whatYouGet3": "Have a voice in what and how the next features look",
+    "step1_joinShape": "join and shape",
+    "step1_future": "future",
+    "step1_planSponsor_name": "early access, angel sponsor",
+    "step1_planSponsor_price": "$10",
+    "step1_planSponsor_currencyUSD": "USD",
+    "step1_planSponsor_whatYouGet": "You get:",
+    "step1_planSponsor_whatYouGet1": "One time purchase ー no subscriptions",
+    "step1_planSponsor_whatYouGet2": "Free updates for 2 years",
+    "step1_planSponsor_whatYouGet3": "Voice in features we add next",
+    "step1_planSponsor_whatYouGet4": "Sneak peek at our behind-the-scenes development across product, user experience, business strategy, go-to-market, investor pitch, and more…",
     "step1_join": "Join"
   },
   "navigation": {

--- a/src/pages/join/1/index.tsx
+++ b/src/pages/join/1/index.tsx
@@ -24,6 +24,9 @@ export default function JoinMagin() {
   const router = useRouter();
   const locale = Locale as LocaleType;
 
+  // OPTIMIZE: external feature flags settings
+  const flagIsJoinEnabled = false;
+
   return (
     <div className='mgn-try-magin bg-white'>
       {/* REFACTOR: convert into component, accept 4 children elements */}
@@ -32,33 +35,57 @@ export default function JoinMagin() {
           <div className='h-full flex align-items-center text-center'>
             <div className='w-full'>
               <h1>{locale.join.step1_wantMore}</h1>
-              <h2>{locale.join.step1_shapeItsFuture}</h2>
-              <div className='flex justify-content-center mt-20'>
-                <div className='text-left max-w-min whitespace-nowrap'>
-                  <p>{locale.join.step1_whatYouGet}</p>
-                  <ul>
-                    <li>{locale.join.step1_whatYouGet1}</li>
-                    <li>{locale.join.step1_whatYouGet2}</li>
-                    <li>{locale.join.step1_whatYouGet3}</li>
-                  </ul>
-                </div>
-              </div>
+              <h2>
+                {locale.join.step1_joinShape}{' '}
+                <span className='mgn-text-blue-rb'>{locale.general.magin}</span>{' '}
+                {locale.join.step1_future}
+              </h2>
+
+              {/* Join */}
+              <p className='text-2xl font-bold mt-10'>
+                <span className='text-base font-normal'>{locale.join.step1_planSponsor_name}</span>
+                <br />
+                {locale.join.step1_planSponsor_price}{' '}
+                <span className='text-sm'>{locale.join.step1_planSponsor_currencyUSD}</span>
+              </p>
               <Button
                 className='text-xl text-size-medium mgn-cta-primary m-1'
                 onClick={() => {
-                  window.location.href = stripePaymentUrl;
+                  if (flagIsJoinEnabled) {
+                    window.location.href = stripePaymentUrl;
+                  }
                 }}
+                tooltip={locale.general.comingSoon}
+                tooltipOptions={{ position: 'bottom' }}
               >
                 {locale.join.step1_join}
               </Button>
-              <br />
-              <Link className='text-sm' href='/terms-conditions'>
-                {locale.about.termsConditions}
-              </Link>
-              &nbsp;|&nbsp;
-              <Link className='text-sm' href='/privacy'>
-                {locale.about.privacy}
-              </Link>
+
+              {/* What you get */}
+              <div className='flex justify-content-center mt-20'>
+                <div className='text-left '>
+                  <p>{locale.join.step1_planSponsor_whatYouGet}</p>
+                  <ul>
+                    <li>{locale.join.step1_planSponsor_whatYouGet1}</li>
+                    <li>{locale.join.step1_planSponsor_whatYouGet2}</li>
+                    <li>{locale.join.step1_planSponsor_whatYouGet3}</li>
+                    <li>{locale.join.step1_planSponsor_whatYouGet4}</li>
+                  </ul>
+                </div>
+              </div>
+
+              {/* Legal */}
+              {flagIsJoinEnabled && (
+                <div className='mt-3'>
+                  <Link className='text-sm' href='/terms-conditions'>
+                    {locale.about.termsConditions}
+                  </Link>
+                  &nbsp;|&nbsp;
+                  <Link className='text-sm' href='/privacy'>
+                    {locale.about.privacy}
+                  </Link>
+                </div>
+              )}
             </div>
           </div>
 

--- a/src/pages/join/1/index.tsx
+++ b/src/pages/join/1/index.tsx
@@ -30,7 +30,7 @@ export default function JoinMagin() {
       <div className='mgn-preview flex w-screen h-screen p-3 justify-content-center align-items-center'>
         <div className='mgn-step flex flex-column w-full h-full justify-content-between sm:max-w-24rem sm:max-h-50rem'>
           <div className='h-full flex align-items-center text-center'>
-            <div>
+            <div className='w-full'>
               <h1>{locale.join.step1_wantMore}</h1>
               <h2>{locale.join.step1_shapeItsFuture}</h2>
               <div className='mt-20 text-left'>

--- a/src/pages/join/1/index.tsx
+++ b/src/pages/join/1/index.tsx
@@ -33,13 +33,15 @@ export default function JoinMagin() {
             <div className='w-full'>
               <h1>{locale.join.step1_wantMore}</h1>
               <h2>{locale.join.step1_shapeItsFuture}</h2>
-              <div className='mt-20 text-left'>
-                {locale.join.step1_whatYouGet}{' '}
-                <ul>
-                  <li>{locale.join.step1_whatYouGet1}</li>
-                  <li>{locale.join.step1_whatYouGet2}</li>
-                  <li>{locale.join.step1_whatYouGet3}</li>
-                </ul>
+              <div className='flex justify-content-center mt-20'>
+                <div className='text-left max-w-min whitespace-nowrap'>
+                  <p>{locale.join.step1_whatYouGet}</p>
+                  <ul>
+                    <li>{locale.join.step1_whatYouGet1}</li>
+                    <li>{locale.join.step1_whatYouGet2}</li>
+                    <li>{locale.join.step1_whatYouGet3}</li>
+                  </ul>
+                </div>
               </div>
               <Button
                 className='text-xl text-size-medium mgn-cta-primary m-1'

--- a/src/pages/join/1/index.tsx
+++ b/src/pages/join/1/index.tsx
@@ -62,18 +62,14 @@ export default function JoinMagin() {
 
           {/* REFACTOR: use next layout */}
           <Navigation
-            left={{
+            middle={{
+              className: 'mgn-cta-secondary',
               label: locale.navigation.back,
               onClick: () => {
                 router.push('/try-magin/3');
               },
             }}
-            right={{
-              label: locale.join.step1_join,
-              onClick: () => {
-                window.location.href = stripePaymentUrl;
-              },
-            }}
+            className='justify-content-center'
           />
         </div>
       </div>

--- a/src/pages/try-magin/1/index.tsx
+++ b/src/pages/try-magin/1/index.tsx
@@ -28,12 +28,14 @@ export default function MarginPreview() {
           {/* REFACTOR: use next layout */}
           <Navigation
             left={{
+              className: 'mgn-cta-secondary',
               label: locale.navigation.returnHome,
               onClick: () => {
                 router.push('/');
               },
             }}
             right={{
+              className: 'mgn-cta-primary',
               label: locale.guide.step1_watchNovel,
               onClick: () => {
                 router.push('/try-magin/2');

--- a/src/pages/try-magin/2/index.tsx
+++ b/src/pages/try-magin/2/index.tsx
@@ -52,12 +52,14 @@ export default function MarginPreview() {
           {/* REFACTOR: use next layout */}
           <Navigation
             left={{
+              className: 'mgn-cta-secondary',
               label: locale.navigation.back,
               onClick: () => {
                 router.push('/try-magin/1');
               },
             }}
             right={{
+              className: 'mgn-cta-primary',
               label: locale.guide.step2_showMe,
               onClick: () => {
                 router.push('/try-magin/3');

--- a/src/pages/try-magin/3/index.tsx
+++ b/src/pages/try-magin/3/index.tsx
@@ -40,12 +40,14 @@ export default function MarginPreview() {
           {/* REFACTOR: use next layout */}
           <Navigation
             left={{
+              className: 'mgn-cta-secondary',
               label: locale.navigation.back,
               onClick: () => {
                 router.push('/try-magin/2');
               },
             }}
             right={{
+              className: 'mgn-cta-primary',
               label: locale.guide.step2_showMe,
               onClick: () => {
                 router.push('/join/1');


### PR DESCRIPTION
# What

enhance:
- JoinMagin: match copy, layout, and style to final design
- JoinMagin: use feature flag to disable join button, legal links
- JoinMagin: show only back button in middle

- fix | JoinMagin: center content in page
- fix | JoinMagin: center subtext in main section
- refactor | Navigation: support a middle button, apply classNames from props
# Checklist

[⏭️] I have added enough test cases
[✔︎] I have self-reviewed the changes and have added explanatory comments as needed

Legend: ✔︎ (done), ⏭️ (skipped), ❌ (not done)