### PR TITLE
enhance | JoinMagin: change second cta to return home

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -26,14 +26,14 @@
     "step1_wantMore": "Want to see more",
     "step1_joinShape": "join and shape",
     "step1_future": "future",
-    "step1_planSponsor_name": "early access, angel sponsor",
-    "step1_planSponsor_price": "$10",
+    "step1_planSponsor_name": "early access sponsor",
+    "step1_planSponsor_price": "$5",
     "step1_planSponsor_currencyUSD": "USD",
     "step1_planSponsor_whatYouGet": "You get:",
     "step1_planSponsor_whatYouGet1": "One time purchase ー no subscriptions",
     "step1_planSponsor_whatYouGet2": "Free updates for 2 years",
-    "step1_planSponsor_whatYouGet3": "Voice in features we add next",
-    "step1_planSponsor_whatYouGet4": "Sneak peek at our behind-the-scenes development across product, user experience, business strategy, go-to-market, investor pitch, and more…",
+    "step1_planSponsor_whatYouGet3": "Voice in what features we add next",
+    "step1_planSponsor_whatYouGet4": "Shape the design and experience",
     "step1_join": "Join"
   },
   "navigation": {

--- a/src/pages/join/1/index.tsx
+++ b/src/pages/join/1/index.tsx
@@ -42,12 +42,13 @@ export default function JoinMagin() {
               </div>
 
               {/* Join */}
-              <p className='text-2xl font-bold mt-10'>
-                <span className='text-base font-normal'>{locale.join.step1_planSponsor_name}</span>
-                <br />
-                {locale.join.step1_planSponsor_price}{' '}
-                <span className='text-sm'>{locale.join.step1_planSponsor_currencyUSD}</span>
-              </p>
+              <div className='text-2xl font-bold mt-10'>
+                <div className='text-base mb-1'>{locale.join.step1_planSponsor_name}</div>
+                <div className='mb-1 mgn-text-blue-rb'>
+                  {locale.join.step1_planSponsor_price}{' '}
+                  <span className='text-sm'>{locale.join.step1_planSponsor_currencyUSD}</span>
+                </div>
+              </div>
               <Button
                 className='text-xl text-size-medium mgn-cta-primary m-1'
                 onClick={() => {

--- a/src/pages/join/1/index.tsx
+++ b/src/pages/join/1/index.tsx
@@ -63,8 +63,8 @@ export default function JoinMagin() {
               </Button>
 
               {/* What you get */}
-              <div className='flex justify-content-center mt-20'>
-                <div className='text-left'>
+              <div className='flex justify-content-center mt-3 mx-5'>
+                <div className='text-left text-sm'>
                   <p>{locale.join.step1_planSponsor_whatYouGet}</p>
                   <ul className='m-0'>
                     <li>{locale.join.step1_planSponsor_whatYouGet1}</li>

--- a/src/pages/join/1/index.tsx
+++ b/src/pages/join/1/index.tsx
@@ -94,9 +94,9 @@ export default function JoinMagin() {
           <Navigation
             middle={{
               className: 'mgn-cta-secondary',
-              label: locale.navigation.back,
+              label: locale.navigation.returnHome,
               onClick: () => {
-                router.push('/try-magin/3');
+                router.push('/');
               },
             }}
             className='justify-content-center'

--- a/src/pages/join/1/index.tsx
+++ b/src/pages/join/1/index.tsx
@@ -65,7 +65,7 @@ export default function JoinMagin() {
               <div className='flex justify-content-center mt-20'>
                 <div className='text-left '>
                   <p>{locale.join.step1_planSponsor_whatYouGet}</p>
-                  <ul>
+                  <ul className='m-0'>
                     <li>{locale.join.step1_planSponsor_whatYouGet1}</li>
                     <li>{locale.join.step1_planSponsor_whatYouGet2}</li>
                     <li>{locale.join.step1_planSponsor_whatYouGet3}</li>

--- a/src/pages/join/1/index.tsx
+++ b/src/pages/join/1/index.tsx
@@ -37,7 +37,7 @@ export default function JoinMagin() {
               <h1>{locale.join.step1_wantMore}</h1>
               <div className='text-lg font-bold'>
                 {locale.join.step1_joinShape}{' '}
-                <span className='mgn-text-blue-rb'>{locale.general.magin}</span>{' '}
+                <span className='mgn-text-blue-rb'>{locale.general.magin}&apos;s</span>{' '}
                 {locale.join.step1_future}
               </div>
 

--- a/src/pages/join/1/index.tsx
+++ b/src/pages/join/1/index.tsx
@@ -63,7 +63,7 @@ export default function JoinMagin() {
 
               {/* What you get */}
               <div className='flex justify-content-center mt-20'>
-                <div className='text-left '>
+                <div className='text-left'>
                   <p>{locale.join.step1_planSponsor_whatYouGet}</p>
                   <ul className='m-0'>
                     <li>{locale.join.step1_planSponsor_whatYouGet1}</li>

--- a/src/pages/join/1/index.tsx
+++ b/src/pages/join/1/index.tsx
@@ -35,11 +35,11 @@ export default function JoinMagin() {
           <div className='h-full flex align-items-center text-center'>
             <div className='w-full'>
               <h1>{locale.join.step1_wantMore}</h1>
-              <h2>
+              <div className='text-lg font-bold'>
                 {locale.join.step1_joinShape}{' '}
                 <span className='mgn-text-blue-rb'>{locale.general.magin}</span>{' '}
                 {locale.join.step1_future}
-              </h2>
+              </div>
 
               {/* Join */}
               <p className='text-2xl font-bold mt-10'>


### PR DESCRIPTION
# What

enhance:
- JoinMagin: change second cta to return home
- JoinMagin: adjust spacing and font size on what you get section
-  JoinMagin: apply final style to plan display
- JoinMagin: remove padding before you get bullet points
- JoinMagin: style the price blue-rb
- JoinMagin: to latest copy

- refactor | JoinMagin: use div instead of div
- style | JoinMagin

# Checklist

[⏭️] I have added enough test cases

Legend: ✔︎ (done), ⏭️ (skipped), ❌ (not done)
