### PR TITLE
enhance | MaginPreview: finalize style on allsteps

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -52,6 +52,7 @@ module.exports = {
     'react/jsx-filename-extension': ['off', { extensions: ['.jsx', '.tsx'] }],
     'react/jsx-no-undef': 'off',
     'react/jsx-props-no-spreading': 'warn',
+    'react/no-unescaped-entities': ['error', { forbid: ['{', '>', '}'] }],
     'react/prop-types': 'off',
     'react/react-in-jsx-scope': 'off',
     'react/require-default-props': 'off',

--- a/src/components/Book/Book.tsx
+++ b/src/components/Book/Book.tsx
@@ -14,7 +14,7 @@ export default function Book(props: Props) {
   const onClick = () => console.log('prev/next click');
 
   return (
-    <div className={`mgn-book flex h-full flex-1 items-center	items-stretch ${className}`}>
+    <div className={`mgn-book flex ${className}`}>
       {showPageControls && (
         <PageControl action='prev' onClick={onClick} className='px-1' isShown={false} />
       )}

--- a/src/components/Book/Book.tsx
+++ b/src/components/Book/Book.tsx
@@ -18,7 +18,9 @@ export default function Book(props: Props) {
       {showPageControls && (
         <PageControl action='prev' onClick={onClick} className='px-1' isShown={false} />
       )}
+
       <Page maginPreviewStep={maginPreviewStep} />
+
       {showPageControls && <PageControl action='next' onClick={onClick} className='px-1' />}
     </div>
   );

--- a/src/components/Book/Page/Page.tsx
+++ b/src/components/Book/Page/Page.tsx
@@ -15,7 +15,6 @@ export default function Page(props: Props) {
   // REFACTOR: import content from a file
   const contentMaginPreviewStep2 = (
     <Scene sceneNum={1} className='pl-2'>
-      <h2 className='mb-4 font-bold'>Chapter 1</h2>
       <p>"What's two plus two?"</p>
       <p>Something about the question irritates me. I'm tired. I drift back to sleep.</p>
     </Scene>
@@ -94,6 +93,7 @@ export default function Page(props: Props) {
   return (
     <div className={`${styles['mgn-page']} flex flex-1 ${className}`}>
       <div className='w-full flex-1 overflow-hidden bg-[#f8f1e3] text-left font-theano text-sm text-black'>
+        <h2 className='mb-4 text-lg'>Chapter 1</h2>
         {content}
       </div>
     </div>

--- a/src/components/Book/Page/Page.tsx
+++ b/src/components/Book/Page/Page.tsx
@@ -93,7 +93,7 @@ export default function Page(props: Props) {
   return (
     <div className={`${styles['mgn-page']} flex flex-1 ${className}`}>
       <div className='w-full flex-1 overflow-hidden bg-[#f8f1e3] text-left font-theano text-sm text-black'>
-        <h2 className='mb-4 text-lg'>Chapter 1</h2>
+        <h2 className='my-2 text-lg'>Chapter 1</h2>
         {content}
       </div>
     </div>

--- a/src/components/Book/Page/Page.tsx
+++ b/src/components/Book/Page/Page.tsx
@@ -16,29 +16,29 @@ export default function Page(props: Props) {
   const contentMaginPreviewStep2 = (
     <Scene sceneNum={1} className='pl-2'>
       <h2 className='mb-4 font-bold'>Chapter 1</h2>
-      <p>“What’s two plus two?”</p>
-      <p>Something about the question irritates me. I’m tired. I drift back to sleep.</p>
+      <p>"What's two plus two?"</p>
+      <p>Something about the question irritates me. I'm tired. I drift back to sleep.</p>
     </Scene>
   );
 
   const contentMaginPreviewStep3 = (
     <>
       <Scene sceneNum={1} className='pl-2'>
-        <p>“What’s two plus two?”</p>
-        <p>Something about the question irritates me. I’m tired. I drift back to sleep.</p>
+        <p>"What's two plus two?"</p>
+        <p>Something about the question irritates me. I'm tired. I drift back to sleep.</p>
       </Scene>
       <Scene sceneNum={2} className='pl-2'>
         <p>A few minutes pass, then I hear it again.</p>
-        <p>“What’s two plus two?”</p>
+        <p>"What's two plus two?"</p>
         <p>
           The soft, feminine voice lacks emotion and the pronunciation is identical to the previous
-          time she said it. It’s a computer. A computer is hassling me. I’m even more irritated now.
+          time she said it. It's a computer. A computer is hassling me. I'm even more irritated now.
         </p>
         <p>
-          “Lrmln,” I say. I’m surprised. I meant to say “Leave me alone”—a completely reasonable
+          "Lrmln," I say. I'm surprised. I meant to say "Leave me alone"—a completely reasonable
           response in my opinion—but I failed to speak.
         </p>
-        <p>“Incorrect,” says the computer. “What’s two plus two?”</p>
+        <p>"Incorrect," says the computer. "What's two plus two?"</p>
       </Scene>
     </>
   );
@@ -48,32 +48,32 @@ export default function Page(props: Props) {
       {/* REFACTOR: accept the content from a parameter */}
       <p>Chapter 1</p>
       <Scene sceneNum={1} className='pl-2'>
-        <p>“What’s two plus two?”</p>
-        <p>Something about the question irritates me. I’m tired. I drift back to sleep.</p>
+        <p>"What's two plus two?"</p>
+        <p>Something about the question irritates me. I'm tired. I drift back to sleep.</p>
       </Scene>
 
       <Scene sceneNum={2} className='pl-2'>
         <p>A few minutes pass, then I hear it again.</p>
-        <p>“What’s two plus two?”</p>
+        <p>"What's two plus two?"</p>
         <p>
           The soft, feminine voice lacks emotion and the pronunciation is identical to the previous
-          time she said it. It’s a computer. A computer is hassling me. I’m even more irritated now.
+          time she said it. It's a computer. A computer is hassling me. I'm even more irritated now.
         </p>
         <p>
-          “Lrmln,” I say. I’m surprised. I meant to say “Leave me alone”—a completely reasonable
+          "Lrmln," I say. I'm surprised. I meant to say "Leave me alone"—a completely reasonable
           response in my opinion—but I failed to speak.
         </p>
-        <p>“Incorrect,” says the computer. “What’s two plus two?”</p>
+        <p>"Incorrect," says the computer. "What's two plus two?"</p>
       </Scene>
 
       <Scene sceneNum={3} className='pl-2'>
-        <p>Time for an experiment. I’ll try to say hello.</p>
-        <p>“Hlllch?” I say.</p>
-        <p>“Incorrect. What’s two plus two?”</p>
+        <p>Time for an experiment. I'll try to say hello.</p>
+        <p>"Hlllch?" I say.</p>
+        <p>"Incorrect. What's two plus two?"</p>
         <p>
-          What’s going on? I want to find out, but I don’t have much to work with. I can’t see. I
-          can’t hear anything other than the computer. I can’t even feel. No, that’s not true. I
-          feel something. I’m lying down. I’m on something soft. A bed.
+          What's going on? I want to find out, but I don't have much to work with. I can't see. I
+          can't hear anything other than the computer. I can't even feel. No, that's not true. I
+          feel something. I'm lying down. I'm on something soft. A bed.
         </p>
       </Scene>
     </>

--- a/src/components/GuideMessage.tsx
+++ b/src/components/GuideMessage.tsx
@@ -12,5 +12,7 @@ export default function GuideMessage(props: Props) {
   // TODO: log if message is empty string
   // REFACTOR: define standard padding in global.css
   // OPTIMIZE: make color a parm
-  return <div className={`mgn-guide p-1 text-center text-green-800 ${className}`}>{children}</div>;
+  return (
+    <div className={`mgn-guide p-1 text-center text-blue-rb-600 ${className}`}>{children}</div>
+  );
 }

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -48,9 +48,9 @@ export default function Home() {
       {/* FIXME: remove extra white space below icon */}
       <Button
         aria-label='magin on GitHub'
-        className='mgn-bg-github m-0 w-max flex-none border-none !bg-[#161b22] p-0.5 text-xs text-white'
+        className='mgn-github m-0 w-max flex-none border-none !bg-[#161b22] p-0.5 pl-2 text-xs text-white'
         icon={
-          <span className='p-button-icon-right m-0 ml-1 w-8 bg-[#F5F5F5] p-0.5 '>
+          <span className='p-button-icon-right m-0 ml-2 w-8 bg-[#F5F5F5] p-0.5'>
             <IconGithub />
           </span>
         }

--- a/src/pages/join/1/index.tsx
+++ b/src/pages/join/1/index.tsx
@@ -29,10 +29,10 @@ export default function JoinMagin() {
   const flagIsJoinEnabled = true;
 
   return (
-    <MainLayout className='mgn-try-magin' layoutKind='app'>
+    <MainLayout className='mgn-try-magin bg-white' layoutKind='app'>
       {/* REFACTOR: convert into component, accept 4 children elements */}
-      <div className='mgn-preview flex h-screen justify-center p-3'>
-        <div className='mgn-step flex flex-1 flex-col justify-between bg-white sm:max-h-[50rem] sm:max-w-[24rem]'>
+      <div className='mgn-preview flex h-screen flex-col items-center justify-center'>
+        <div className='mgn-step flex w-full flex-1 flex-col justify-between bg-yellow-rb-200 sm:max-h-[51rem] sm:max-w-[25rem]'>
           <div className='flex flex-1 items-center text-center'>
             <div className='w-full'>
               <h1>{locale.join.step1_wantMore}</h1>

--- a/src/pages/try-magin/1/index.tsx
+++ b/src/pages/try-magin/1/index.tsx
@@ -21,6 +21,7 @@ export default function MarginPreview() {
     if (!bookTitle) throw Error('bookTitle is not assigned');
     else if (!bookTitle.textContent) throw Error('bookTitle.textContext is not assigned');
 
+    // TODO: shorten duration time
     bookTitle.innerHTML = bookTitle.textContent.replace(/\S/g, "<span class='letter'>$&</span>");
     anime
       .timeline({ loop: false })
@@ -44,7 +45,8 @@ export default function MarginPreview() {
       {/* REFACTOR: convert into component, accept 4 children elements */}
       <div className='mgn-preview flex h-screen flex-col items-center justify-center'>
         <div className='mgn-step flex w-full flex-1 flex-col justify-between bg-yellow-rb-200 sm:max-h-[51rem] sm:max-w-[25rem]'>
-          <GuideMessage className='flex max-h-[32rem] flex-1 items-end justify-center sm:max-h-[75%]'>
+          {/* REFACTOR: into top, middle, button div elements, put the guide message into the bottom */}
+          <GuideMessage className='flex max-h-[32rem] flex-1 items-end justify-center sm:max-h-[40rem]'>
             <h2 className='text-blue-rb-600'>
               {locale.guide.step1_maginPresents}
               <br />

--- a/src/pages/try-magin/1/index.tsx
+++ b/src/pages/try-magin/1/index.tsx
@@ -15,6 +15,7 @@ export default function MarginPreview() {
   const router = useRouter();
   const bookTitleRef = useRef<HTMLSpanElement | null>(null);
 
+  // REFACTOR: move into a helper function
   useEffect(() => {
     const bookTitle = bookTitleRef.current;
     if (!bookTitle) throw Error('bookTitle is not assigned');

--- a/src/pages/try-magin/2/index.tsx
+++ b/src/pages/try-magin/2/index.tsx
@@ -24,10 +24,10 @@ export default function MarginPreview() {
   const locale = Locale as LocaleType;
 
   return (
-    <MainLayout className='mgn-try-magin' layoutKind='app'>
+    <MainLayout className='mgn-try-magin bg-white' layoutKind='app'>
       {/* REFACTOR: convert into component, accept 4 children elements */}
-      <div className='mgn-preview flex h-screen justify-center p-3'>
-        <div className='mgn-step flex flex-1 flex-col bg-white sm:max-h-[50rem] sm:max-w-[24rem]'>
+      <div className='mgn-preview flex h-screen flex-col items-center justify-center'>
+        <div className='mgn-step flex w-full flex-1 flex-col justify-between bg-yellow-rb-200 sm:max-h-[51rem] sm:max-w-[25rem]'>
           {/* REFACTOR: make content an optional parameter */}
           <GuideMessage className='font-bold'>{locale.guide.step2_read}</GuideMessage>
           <Book maginPreviewStep={2} showPageControls={false} className='flex-1' />

--- a/src/pages/try-magin/2/index.tsx
+++ b/src/pages/try-magin/2/index.tsx
@@ -28,26 +28,29 @@ export default function MarginPreview() {
       {/* REFACTOR: convert into component, accept 4 children elements */}
       <div className='mgn-preview flex h-screen flex-col items-center justify-center'>
         <div className='mgn-step flex w-full flex-1 flex-col justify-between bg-yellow-rb-200 sm:max-h-[51rem] sm:max-w-[25rem]'>
-          {/* REFACTOR: make content an optional parameter */}
-          <GuideMessage className='font-bold'>{locale.guide.step2_read}</GuideMessage>
-          <Book maginPreviewStep={2} showPageControls={false} className='flex-1' />
+          <div className='mgn-step-top col flex flex-1 flex-col justify-center'>
+            <Book maginPreviewStep={2} showPageControls={false} className='' />
+          </div>
 
-          {/* TODO: show on a 5 second delay */}
-          {/* OPTIMIZE: figure out how to allow \n in the string and convert in to <br /> */}
-          <GuideMessage className='font-bold'>{locale.guide.step2_movieSceen}</GuideMessage>
+          <div className='mgn-step-middle'>
+            {/* REFACTOR: make content an optional parameter */}
+            <GuideMessage className='font-bold'>{locale.guide.step2_read}</GuideMessage>
+          </div>
 
-          <div className='justify-content-start relative flex flex-1 flex-col items-center'>
-            <Image
-              src='/assets/common/images/movie-screen.webp'
-              alt='people in a theatre watching a movie'
-              className='w-20rem h-auto !object-scale-down'
-              width='640'
-              height='364'
-            />
-            <GuideMessage className='font-bold'>
-              {/* TODO: show on a 1 second delay */}
-              {locale.guide.step2_whatWould}
-            </GuideMessage>
+          <div className='mgn-step-bottom flex flex-1 items-center'>
+            {/* TODO: show on a 5 second delay */}
+            {/* OPTIMIZE: figure out how to allow \n in the string and convert in to <br /> */}
+            {/* <GuideMessage className='font-bold'>{locale.guide.step2_movieSceen}</GuideMessage> */}
+
+            <div className='flex flex-col items-center'>
+              <Image
+                src='/assets/common/images/movie-screen.webp'
+                alt='people in a theatre watching a movie'
+                className='w-20rem h-auto !object-scale-down'
+                width='640'
+                height='364'
+              />
+            </div>
           </div>
 
           {/* REFACTOR: use next layout */}

--- a/src/pages/try-magin/3/index.tsx
+++ b/src/pages/try-magin/3/index.tsx
@@ -24,10 +24,10 @@ export default function MarginPreview() {
   const locale = Locale as LocaleType;
 
   return (
-    <MainLayout className='mgn-try-magin' layoutKind='app'>
+    <MainLayout className='mgn-try-magin bg-white' layoutKind='app'>
       {/* REFACTOR: convert into component, accept 4 children elements */}
-      <div className='mgn-preview flex h-screen justify-center p-3'>
-        <div className='mgn-step flex flex-1 flex-col justify-between bg-white sm:max-h-[50rem] sm:max-w-[24rem]'>
+      <div className='mgn-preview flex h-screen flex-col items-center justify-center'>
+        <div className='mgn-step flex w-full flex-1 flex-col justify-between bg-yellow-rb-200 sm:max-h-[51rem] sm:max-w-[25rem]'>
           <Book maginPreviewStep={3} showPageControls className='flex-1' />
           <GuideMessage className='font-bold'>
             {/* TODO: show on a 5 second delay */}

--- a/src/pages/try-magin/3/index.tsx
+++ b/src/pages/try-magin/3/index.tsx
@@ -11,6 +11,8 @@ import MainLayout from '@/layouts/MainLayout';
 // OPTIMIZE: read based on language
 import Locale from '@/locales/en.json';
 
+import styles from '../try-magin.module.scss';
+
 // REFACTOR: move into LocaleType.ts file
 interface LocalePropType {
   [key: string]: string;
@@ -26,7 +28,9 @@ export default function MarginPreview() {
   return (
     <MainLayout className='mgn-try-magin bg-white' layoutKind='app'>
       {/* REFACTOR: convert into component, accept 4 children elements */}
-      <div className='mgn-preview flex h-screen flex-col items-center justify-center'>
+      <div
+        className={`${styles['mgn-preview']} flex h-screen flex-col items-center justify-center`}
+      >
         <div className='mgn-step flex	w-full flex-1 flex-col justify-between bg-yellow-rb-200 sm:max-h-[51rem] sm:max-w-[25rem]'>
           <div className='mgn-step-top col max-h-for-screen flex flex-1 flex-col justify-center'>
             <Book maginPreviewStep={3} showPageControls className='flex-1 overflow-hidden' />

--- a/src/pages/try-magin/3/index.tsx
+++ b/src/pages/try-magin/3/index.tsx
@@ -27,16 +27,24 @@ export default function MarginPreview() {
     <MainLayout className='mgn-try-magin bg-white' layoutKind='app'>
       {/* REFACTOR: convert into component, accept 4 children elements */}
       <div className='mgn-preview flex h-screen flex-col items-center justify-center'>
-        <div className='mgn-step flex w-full flex-1 flex-col justify-between bg-yellow-rb-200 sm:max-h-[51rem] sm:max-w-[25rem]'>
-          <Book maginPreviewStep={3} showPageControls className='flex-1' />
-          <GuideMessage className='font-bold'>
-            {/* TODO: show on a 5 second delay */}
-            {/* OPTIMIZE: figure out how to allow \n in the string and convert in to <br /> */}
-            {/* OPTIMIZE: create a component to cycle through the array with a delay */}
-            {locale.guide.step3_1} <br />
-            {locale.guide.step3_2} <br />
-          </GuideMessage>
-          <Film className='flex-1' />
+        <div className='mgn-step flex	w-full flex-1 flex-col justify-between bg-yellow-rb-200 sm:max-h-[51rem] sm:max-w-[25rem]'>
+          <div className='mgn-step-top col max-h-for-screen flex flex-1 flex-col justify-center'>
+            <Book maginPreviewStep={3} showPageControls className='flex-1 overflow-hidden' />
+          </div>
+
+          <div className='mgn-step-middle'>
+            <GuideMessage className='font-bold'>
+              {/* TODO: show on a 5 second delay */}
+              {/* OPTIMIZE: figure out how to allow \n in the string and convert in to <br /> */}
+              {/* OPTIMIZE: create a component to cycle through the array with a delay */}
+              {locale.guide.step3_1} <br />
+              {locale.guide.step3_2} <br />
+            </GuideMessage>
+          </div>
+
+          <div className='mgn-step-bottom max-h-for-screen flex flex-1 items-center'>
+            <Film className='flex-1' />
+          </div>
 
           {/* REFACTOR: use next layout */}
           <Navigation

--- a/src/pages/try-magin/try-magin.module.scss
+++ b/src/pages/try-magin/try-magin.module.scss
@@ -1,0 +1,22 @@
+// Copyright rigélblu inc.
+// All rights reserved.
+
+.mgn-preview {
+  :global {
+    .max-h-for-screen {
+      // Calculation: (screen  - status bar - navigation bar) / 1rem in px * percent
+      @apply iphone-se:max-h-[13rem]; // (667 - 44 - 140) / 16 * 0.45
+
+      @apply iphone-11:max-h-[19rem]; // (896 - 48 - 140)/ 16 * 0.45
+      @apply iphone-11-pro:max-h-[17rem]; // (812 - 48 - 140) / 16 * 0.45
+      @apply iphone-11-pro-max:max-h-[19rem]; // (896 - 48 - 140) / 16 * 0.45
+
+      @apply iphone-12:max-h-[18rem]; // (844 - 47 - 140) / 16 * 0.45
+      @apply iphone-12-pro:max-h-[20rem]; // (926 - 47 - 140) / 16 * 0.45
+      @apply iphone-12-mini:max-h-[16rem]; // (780 - 44 - 140) / 16 * 0.45
+
+      @apply lg:max-h-[26rem]; // (1024 / 16 * 0.45) - 2
+      // TODO: add ipad, android phones
+    }
+  }
+}

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -19,7 +19,7 @@ h1 {
 }
 
 h2 {
-  @apply mt-6 text-xl font-bold;
+  @apply text-xl font-bold;
 }
 
 h3 {

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -133,19 +133,3 @@ button {
     @apply bg-gray-200 text-black;
   }
 }
-
-.max-h-for-screen {
-  // Calculation: (screen  - status bar - navigation bar) / 1rem in px * percent
-  @apply iphone-se:max-h-[13rem]; // (667 - 44 - 140) / 16 * 0.45
-
-  @apply iphone-11:max-h-[19rem]; // (896 - 48 - 140)/ 16 * 0.45
-  @apply iphone-11-pro:max-h-[17rem]; // (812 - 48 - 140) / 16 * 0.45
-  @apply iphone-11-pro-max:max-h-[19rem]; // (896 - 48 - 140) / 16 * 0.45
-
-  @apply iphone-12:max-h-[18rem]; // (844 - 47 - 140) / 16 * 0.45
-  @apply iphone-12-pro:max-h-[20rem]; // (926 - 47 - 140) / 16 * 0.45
-  @apply iphone-12-mini:max-h-[16rem]; // (780 - 44 - 140) / 16 * 0.45
-
-  @apply lg:max-h-[28rem]; // 1024 / 16 * 0.45
-  // TODO: add ipad, android phones
-}

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -133,3 +133,19 @@ button {
     @apply bg-gray-200 text-black;
   }
 }
+
+.max-h-for-screen {
+  // Calculation: (screen  - status bar - navigation bar) / 1rem in px * percent
+  @apply iphone-se:max-h-[13rem]; // (667 - 44 - 140) / 16 * 0.45
+
+  @apply iphone-11:max-h-[19rem]; // (896 - 48 - 140)/ 16 * 0.45
+  @apply iphone-11-pro:max-h-[17rem]; // (812 - 48 - 140) / 16 * 0.45
+  @apply iphone-11-pro-max:max-h-[19rem]; // (896 - 48 - 140) / 16 * 0.45
+
+  @apply iphone-12:max-h-[18rem]; // (844 - 47 - 140) / 16 * 0.45
+  @apply iphone-12-pro:max-h-[20rem]; // (926 - 47 - 140) / 16 * 0.45
+  @apply iphone-12-mini:max-h-[16rem]; // (780 - 44 - 140) / 16 * 0.45
+
+  @apply lg:max-h-[28rem]; // 1024 / 16 * 0.45
+  // TODO: add ipad, android phones
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -24,6 +24,18 @@ module.exports = {
       },
       fontFamily: { theano: ['Theano Old Style'] },
       fontSize: { xs: '0.875rem', '2xs': '0.75rem' },
+      screens: {
+        'iphone-se': { raw: '(max-height: 667px)' },
+
+        'iphone-11': { raw: '(max-height: 896px)' },
+        'iphone-11-pro': { raw: '(max-height: 812px)' },
+        'iphone-11-pro-max': { raw: '(max-height: 896px)' },
+        
+        'iphone-12': { raw: '(max-height: 844px)' },
+        'iphone-12-pro': { raw: '(max-height: 926px)' },
+        'iphone-12-mini': { raw: '(max-height: 780px)' },
+        // TODO: add ipad, android phones
+      },
     },
   },
   plugins: [],

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,14 +16,14 @@ module.exports = {
     },
 
     extend: {
-      fontFamily: { theano: ['Theano Old Style'] },
-      fontSize: { xs: '0.875rem', '2xs': '0.75rem' },
       colors: {
         'blue-rb-100': '#f4faff',
         'blue-rb-400': '#e4f2ff',
         'blue-rb-600': '#0080ff',
         'yellow-rb-200': '#faf8f4',
       },
+      fontFamily: { theano: ['Theano Old Style'] },
+      fontSize: { xs: '0.875rem', '2xs': '0.75rem' },
     },
   },
   plugins: [],

--- a/tsconfigs/tsconfig.base.next.json
+++ b/tsconfigs/tsconfig.base.next.json
@@ -5,7 +5,7 @@
   "extends": "./tsconfig.base.react.json",
   "compilerOptions": {
     "incremental": true,
-    "target": "esnext"
+    "target": "es5"
   },
   "exclude": ["node_modules"]
 }

--- a/tsconfigs/tsconfig.base.node.json
+++ b/tsconfigs/tsconfig.base.node.json
@@ -10,7 +10,7 @@
     "isolatedModules": true,
     "module": "esnext",
     "moduleResolution": "node",
-    "noEmit": false,
+    "noEmit": true,
     "noImplicitAny": true,
     "noUnusedLocals": true,
     "plugins": [{ "name": "typescript-plugin-css-modules" }],


### PR DESCRIPTION
# What

refactor:
- MarginPreview: move max-h-for-screen into a css module

enhance:
- tsconfig: change target and noemit to nextjs recommended defaults
- eslint: adjust chars require escaping
- MarginPreview: adjust layout into a top, middle, and bottom section
- Page: decrease margin on Chapter text
- Home: add margin/padding on magin on github text
- Book: keep height minimual by default, require adjustment through props
- GuideMessage: change default text color to rb
- tailwind: add iphone screens based on max height
- PreviewMagin: animate book title
- Page: move Chapter text to be outside of the scene

- style | Page: replace ascii chars
enhance: fill available area appropirately for mobile and larger screens

- fix | global.css: h2 accidently added extra margin on top

# Checklist

[⏭️] I have added enough test cases

Legend: ✔︎ (done), ⏭️ (skipped), ❌ (not done)