### PR TITLE
feat | sttep 3a - update page show current scene indicator

### DIFF
--- a/src/components/Book/Book.tsx
+++ b/src/components/Book/Book.tsx
@@ -6,16 +6,16 @@ import Page from './Page';
 
 interface Props {
   className?: string;
-  maginPreviewStep?: number | null; // REFACTOR: create a seperate component, that wraps this one
   onTypingComplete?: () => void;
+  sceneNum: number;
   useTypingAnimation?: boolean;
 }
 
 export default function Book(props: Props) {
   const {
     className = '',
-    maginPreviewStep = null,
     onTypingComplete = undefined,
+    sceneNum,
     useTypingAnimation = false,
   } = props;
 
@@ -24,8 +24,8 @@ export default function Book(props: Props) {
       <div className='w-full'>
         <h2 className='mb-2 text-2xs text-center text-gray-500'>{locale.book.title}</h2>
         <Page
-          maginPreviewStep={maginPreviewStep}
           onTypingComplete={onTypingComplete}
+          sceneNum={sceneNum}
           useTypingAnimation={useTypingAnimation}
         />
       </div>

--- a/src/components/Book/Book.tsx
+++ b/src/components/Book/Book.tsx
@@ -7,12 +7,21 @@ import Page from './Page';
 interface Props {
   className?: string;
   onTypingComplete?: () => void;
-  scene: number;
+  sceneCurrent: number;
+  sceneEnd: number;
+  sceneStart: number;
   useTypingAnimation?: boolean;
 }
 
 export default function Book(props: Props) {
-  const { className = '', onTypingComplete = undefined, scene, useTypingAnimation = false } = props;
+  const {
+    className = '',
+    onTypingComplete = undefined,
+    sceneCurrent,
+    sceneStart,
+    sceneEnd,
+    useTypingAnimation = false,
+  } = props;
 
   return (
     <div className={`mgn-book flex w-full flex-1 ${className}`}>
@@ -20,7 +29,9 @@ export default function Book(props: Props) {
         <h2 className='mb-2 text-2xs text-center text-gray-500'>{locale.book.title}</h2>
         <Page
           onTypingComplete={onTypingComplete}
-          scene={scene}
+          sceneCurrent={sceneCurrent}
+          sceneEnd={sceneEnd}
+          sceneStart={sceneStart}
           useTypingAnimation={useTypingAnimation}
         />
       </div>

--- a/src/components/Book/Book.tsx
+++ b/src/components/Book/Book.tsx
@@ -7,17 +7,12 @@ import Page from './Page';
 interface Props {
   className?: string;
   onTypingComplete?: () => void;
-  sceneNum: number;
+  scene: number;
   useTypingAnimation?: boolean;
 }
 
 export default function Book(props: Props) {
-  const {
-    className = '',
-    onTypingComplete = undefined,
-    sceneNum,
-    useTypingAnimation = false,
-  } = props;
+  const { className = '', onTypingComplete = undefined, scene, useTypingAnimation = false } = props;
 
   return (
     <div className={`mgn-book flex w-full flex-1 ${className}`}>
@@ -25,7 +20,7 @@ export default function Book(props: Props) {
         <h2 className='mb-2 text-2xs text-center text-gray-500'>{locale.book.title}</h2>
         <Page
           onTypingComplete={onTypingComplete}
-          sceneNum={sceneNum}
+          scene={scene}
           useTypingAnimation={useTypingAnimation}
         />
       </div>

--- a/src/components/Book/Page.module.scss
+++ b/src/components/Book/Page.module.scss
@@ -1,0 +1,8 @@
+// Copyright rigélblu inc.
+// All rights reserved.
+
+.mgn-page {
+  p {
+    @apply mb-[0.1rem] indent-3.5;
+  }
+}

--- a/src/components/Book/Page.tsx
+++ b/src/components/Book/Page.tsx
@@ -3,8 +3,8 @@
 import { useRef, useEffect } from 'react';
 import Typed from 'typed.js';
 import SceneMarker from '@/components/SceneMarker/SceneMarker';
-
 import settings, { MODE } from '@/config/settings';
+import styles from './Page.module.scss';
 
 type Props = {
   className?: string;
@@ -156,7 +156,7 @@ export default function Page(props: Props) {
   }
 
   return (
-    <div className={`mgn-page flex flex-1 ${className}`}>
+    <div className={`${styles['mgn-page']} flex flex-1 ${className}`}>
       <div className='flex-1 overflow-hidden bg-[#f8f1e3] text-left font-theano text-sm text-black'>
         {content}
       </div>

--- a/src/components/Book/Page.tsx
+++ b/src/components/Book/Page.tsx
@@ -69,7 +69,7 @@ export default function Page(props: Props) {
   // REFACTOR: step 2, 3, etc into an array
   // REFACTOR: import content from a file
   const contentScene1 = (
-    <SceneMarker className='pl-2'>
+    <>
       <h3 className='my-2 text-lg'>Chapter 1</h3>
 
       <p>
@@ -81,11 +81,11 @@ export default function Page(props: Props) {
           {/* HACK: typed.js is inserting style when dynimically removing id, preventing the text
                     from display when useTypingAnimation is false. */}
           {useTypingAnimation && <span id='typed-strings'>{contentScene1Typed}</span>}
-          {!useTypingAnimation && <span>{contentScene1Typed}</span>}
+          {!useTypingAnimation && <SceneMarker className='pl-2'>{contentScene1Typed}</SceneMarker>}
         </span>
-        {useTypingAnimation && <span id='typed' />}
+        {useTypingAnimation && <span id='typed' className='pl-2' />}
       </p>
-    </SceneMarker>
+    </>
   );
 
   const contentScene2 = (

--- a/src/components/Book/Page.tsx
+++ b/src/components/Book/Page.tsx
@@ -30,8 +30,9 @@ export default function Page(props: Props) {
   const contentScenes = [
     // FIXME: add key
     // eslint-disable-next-line react/jsx-key
-    <h3 className='my-2 text-lg'>Chapter 1</h3>,
-    <>
+    <h3 className='my-2 pl-2 text-lg'>Chapter 1</h3>,
+    // eslint-disable-next-line react/jsx-key
+    <div className='pl-2'>
       <p>"What's two plus two?"</p>
       <p>Something about the question irritates me. I'm tired. I drift back to sleep.</p>
       <p>A few minutes pass, then I hear it again.</p>
@@ -40,15 +41,17 @@ export default function Page(props: Props) {
         The soft, feminine voice lacks emotion and the pronunciation is identical to the previous
         time she said it. It's a computer. A computer is hassling me. I'm even more irritated now.
       </p>
-    </>,
-    <>
+    </div>,
+    // eslint-disable-next-line react/jsx-key
+    <div className='pl-2'>
       <p>
         "Lrmln," I say. I'm surprised. I meant to say "Leave me alone"—a completely reasonable
         response in my opinion—but I failed to speak.
       </p>
       <p>"Incorrect," says the computer. "What's two plus two?"</p>
-    </>,
-    <>
+    </div>,
+    // eslint-disable-next-line react/jsx-key
+    <div className='pl-2'>
       <p>Time for an experiment. I'll try to say hello.</p>
       <p>"Hlllch?" I say.</p>
       <p>"Incorrect. What's two plus two?"</p>
@@ -57,7 +60,7 @@ export default function Page(props: Props) {
         can't hear anything other than the computer. I can't even feel. No, that's not true. I feel
         something. I'm lying down. I'm on something soft. A bed.
       </p>
-    </>,
+    </div>,
   ];
 
   // HACK: Had to use &nbsp instead of using css to text-indent due to limitation of typed.js, could to str replace too
@@ -128,7 +131,7 @@ export default function Page(props: Props) {
   // REFACTOR: add shot number
   function getContent(sceneStart: number, sceneEnd: number, sceneCurrent: number): React.ReactNode {
     const content = [...contentScenes];
-    content[sceneCurrent] = <SceneMarker className='pl-2'>{content[sceneCurrent]}</SceneMarker>;
+    content[sceneCurrent] = <SceneMarker>{content[sceneCurrent]}</SceneMarker>;
 
     const chapter = [content[0]];
     const pageContent = content.slice(sceneStart, sceneEnd + 1);

--- a/src/components/Book/Page.tsx
+++ b/src/components/Book/Page.tsx
@@ -8,16 +8,16 @@ import settings, { MODE } from '@/config/settings';
 
 interface Props {
   className?: string;
-  maginPreviewStep?: number | null;
   onTypingComplete?: () => void;
+  sceneNum: number;
   useTypingAnimation?: boolean;
 }
 
 export default function Page(props: Props) {
   const {
     className = '',
-    maginPreviewStep = null,
     onTypingComplete = undefined,
+    sceneNum,
     useTypingAnimation = false,
   } = props;
   const refTyped = useRef(null);
@@ -26,7 +26,8 @@ export default function Page(props: Props) {
   // eslint-disable-next-line consistent-return
   useEffect(() => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
-    if (useTypingAnimation && maginPreviewStep === 2) {
+    // HACk: typing animation is only supported on the first scene since typed.js doesn't support multiple <p> strings
+    if (useTypingAnimation && sceneNum === 0) {
       const typed = new Typed('#typed', {
         fadeOut: true,
         loop: false,
@@ -44,11 +45,11 @@ export default function Page(props: Props) {
         typed.destroy();
       };
     }
-  }, [maginPreviewStep, onTypingComplete, typingSpeed, useTypingAnimation]);
+  }, [onTypingComplete, sceneNum, typingSpeed, useTypingAnimation]);
 
   // HACK: Had to use &nbsp instead of using css to text-indent due to limitation of typed.js
   // OPTIMIZE: make typing animation work for any page content
-  const typedText = (
+  const contentScene1Typed = (
     <span>
       What's two plus two?
       <br />
@@ -66,34 +67,34 @@ export default function Page(props: Props) {
 
   // REFACTOR: step 2, 3, etc into an array
   // REFACTOR: import content from a file
-  const contentMaginPreviewStep2 = (
-    <SceneMarker sceneNum={1} className='pl-2'>
+  const contentScene1 = (
+    <SceneMarker className='pl-2'>
       <h3 className='my-2 text-lg'>Chapter 1</h3>
 
       <p>
         <span ref={refTyped}>
           {/* OPTIMIZE: create function to increase pause on every period, question, etc */}
           {/* FIXME: typed.js intermittenly prints ^{typedPuncationMarkPause} instead of pausing.
-                     It also creates a jitter sometimes, where you can see "<" for a split second.
-                     Removing from code until we find a fix. */}
+                    It also creates a jitter sometimes, where you can see "<" for a split second.
+                    Removing from code until we find a fix. */}
           {/* HACK: typed.js is inserting style when dynimically removing id, preventing the text
                     from display when useTypingAnimation is false. */}
-          {useTypingAnimation && <span id='typed-strings'>{typedText}</span>}
-          {!useTypingAnimation && <span>{typedText}</span>}
+          {useTypingAnimation && <span id='typed-strings'>{contentScene1Typed}</span>}
+          {!useTypingAnimation && <span>{contentScene1Typed}</span>}
         </span>
         {useTypingAnimation && <span id='typed' />}
       </p>
     </SceneMarker>
   );
 
-  const contentMaginPreviewStep3 = (
+  const contentScene2 = (
     // REFACTOR: add shot number
     <>
-      <SceneMarker sceneNum={1} className='pl-2'>
+      <SceneMarker className='pl-2'>
         <p>"What's two plus two?"</p>
         <p>Something about the question irritates me. I'm tired. I drift back to sleep.</p>
       </SceneMarker>
-      <SceneMarker sceneNum={2} className='pl-2'>
+      <SceneMarker className='pl-2'>
         <p>A few minutes pass, then I hear it again.</p>
         <p>"What's two plus two?"</p>
         <p>
@@ -109,16 +110,16 @@ export default function Page(props: Props) {
     </>
   );
 
-  const projectHailMary = (
+  const contentScene3 = (
     <>
       {/* REFACTOR: accept the content from a parameter */}
       <p>Chapter 1</p>
-      <SceneMarker sceneNum={1} className='pl-2'>
+      <SceneMarker className='pl-2'>
         <p>"What's two plus two?"</p>
         <p>Something about the question irritates me. I'm tired. I drift back to sleep.</p>
       </SceneMarker>
 
-      <SceneMarker sceneNum={2} className='pl-2'>
+      <SceneMarker className='pl-2'>
         <p>A few minutes pass, then I hear it again.</p>
         <p>"What's two plus two?"</p>
         <p>
@@ -132,7 +133,7 @@ export default function Page(props: Props) {
         <p>"Incorrect," says the computer. "What's two plus two?"</p>
       </SceneMarker>
 
-      <SceneMarker sceneNum={3} className='pl-2'>
+      <SceneMarker className='pl-2'>
         <p>Time for an experiment. I'll try to say hello.</p>
         <p>"Hlllch?" I say.</p>
         <p>"Incorrect. What's two plus two?"</p>
@@ -146,15 +147,18 @@ export default function Page(props: Props) {
   );
 
   let content: React.ReactElement;
-  switch (maginPreviewStep) {
-    case 2:
-      content = contentMaginPreviewStep2;
+  switch (sceneNum) {
+    case 0:
+      content = contentScene1;
+      break;
+    case 1:
+      content = contentScene1;
       break;
     case 3:
-      content = contentMaginPreviewStep3;
+      content = contentScene2;
       break;
     default:
-      content = projectHailMary;
+      content = contentScene3;
   }
 
   return (

--- a/src/components/Book/Page.tsx
+++ b/src/components/Book/Page.tsx
@@ -6,51 +6,64 @@ import SceneMarker from '@/components/SceneMarker/SceneMarker';
 
 import settings, { MODE } from '@/config/settings';
 
-interface Props {
+type Props = {
   className?: string;
   onTypingComplete?: () => void;
-  sceneNum: number;
+  sceneCurrent: number;
+  sceneEnd: number;
+  sceneStart: number;
   useTypingAnimation?: boolean;
-}
+};
 
 export default function Page(props: Props) {
   const {
     className = '',
     onTypingComplete = undefined,
-    sceneNum,
+    sceneCurrent,
+    sceneEnd,
+    sceneStart,
     useTypingAnimation = false,
   } = props;
   const refTyped = useRef(null);
   const typingSpeed = settings.mode !== MODE.DEBUG ? settings.page.typingSpeed : 0;
 
-  // eslint-disable-next-line consistent-return
-  useEffect(() => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
-    // HACk: typing animation is only supported on the first scene since typed.js doesn't support multiple <p> strings
-    if (useTypingAnimation && sceneNum === 0) {
-      const typed = new Typed('#typed', {
-        fadeOut: true,
-        loop: false,
-        stringsElement: '#typed-strings',
-        typeSpeed: typingSpeed,
+  const contentScenes = [
+    // FIXME: add key
+    // eslint-disable-next-line react/jsx-key
+    <h3 className='my-2 text-lg'>Chapter 1</h3>,
+    <>
+      <p>"What's two plus two?"</p>
+      <p>Something about the question irritates me. I'm tired. I drift back to sleep.</p>
+      <p>A few minutes pass, then I hear it again.</p>
+      <p>"What's two plus two?"</p>
+      <p>
+        The soft, feminine voice lacks emotion and the pronunciation is identical to the previous
+        time she said it. It's a computer. A computer is hassling me. I'm even more irritated now.
+      </p>
+    </>,
+    <>
+      <p>
+        "Lrmln," I say. I'm surprised. I meant to say "Leave me alone"—a completely reasonable
+        response in my opinion—but I failed to speak.
+      </p>
+      <p>"Incorrect," says the computer. "What's two plus two?"</p>
+    </>,
+    <>
+      <p>Time for an experiment. I'll try to say hello.</p>
+      <p>"Hlllch?" I say.</p>
+      <p>"Incorrect. What's two plus two?"</p>
+      <p>
+        What's going on? I want to find out, but I don't have much to work with. I can't see. I
+        can't hear anything other than the computer. I can't even feel. No, that's not true. I feel
+        something. I'm lying down. I'm on something soft. A bed.
+      </p>
+    </>,
+  ];
 
-        onComplete: (self) => {
-          const cursor = document.querySelector('.typed-cursor') as HTMLElement;
-          if (cursor) cursor.style.display = 'none';
-          if (onTypingComplete !== undefined) onTypingComplete();
-        },
-      });
-
-      return () => {
-        typed.destroy();
-      };
-    }
-  }, [onTypingComplete, sceneNum, typingSpeed, useTypingAnimation]);
-
-  // HACK: Had to use &nbsp instead of using css to text-indent due to limitation of typed.js
+  // HACK: Had to use &nbsp instead of using css to text-indent due to limitation of typed.js, could to str replace too
   // OPTIMIZE: make typing animation work for any page content
   // OPTIMIZE: move content into data file / firebase
-  const contentScene1Typed = (
+  const contentIntroTyped = (
     <span>
       &nbsp;What's two plus two?
       <br />
@@ -68,9 +81,9 @@ export default function Page(props: Props) {
 
   // REFACTOR: step 2, 3, etc into an array
   // REFACTOR: import content from a file
-  const contentScene1 = (
+  const contentIntro = (
     <>
-      <h3 className='my-2 text-lg'>Chapter 1</h3>
+      {contentScenes[0]}
 
       <p>
         <span ref={refTyped}>
@@ -80,84 +93,66 @@ export default function Page(props: Props) {
                     Removing from code until we find a fix. */}
           {/* HACK: typed.js is inserting style when dynimically removing id, preventing the text
                     from display when useTypingAnimation is false. */}
-          {useTypingAnimation && <span id='typed-strings'>{contentScene1Typed}</span>}
-          {!useTypingAnimation && <SceneMarker className='pl-2'>{contentScene1Typed}</SceneMarker>}
+          {useTypingAnimation && <span id='typed-strings'>{contentIntroTyped}</span>}
+          {!useTypingAnimation && contentIntroTyped}
         </span>
         {useTypingAnimation && <span id='typed' className='pl-2' />}
       </p>
     </>
   );
 
-  const contentScene1and2 = (
-    // REFACTOR: add shot number
-    <>
-      <div className='pl-2'>
-        <p>"What's two plus two?"</p>
-        <p>Something about the question irritates me. I'm tired. I drift back to sleep.</p>
-        <p>A few minutes pass, then I hear it again.</p>
-        <p>"What's two plus two?"</p>
-        <p>
-          The soft, feminine voice lacks emotion and the pronunciation is identical to the previous
-          time she said it. It's a computer. A computer is hassling me. I'm even more irritated now.
-        </p>
-      </div>
+  // eslint-disable-next-line consistent-return
+  useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+    // HACk: typing animation is only supported on the first scene since typed.js doesn't support multiple <p> strings
+    if (useTypingAnimation && sceneCurrent === 0) {
+      const typed = new Typed('#typed', {
+        fadeOut: true,
+        loop: false,
+        stringsElement: '#typed-strings',
+        typeSpeed: typingSpeed,
 
-      <SceneMarker>
-        <p>
-          "Lrmln," I say. I'm surprised. I meant to say "Leave me alone"—a completely reasonable
-          response in my opinion—but I failed to speak.
-        </p>
-        <p>"Incorrect," says the computer. "What's two plus two?"</p>
-      </SceneMarker>
-    </>
-  );
+        onComplete: (self) => {
+          const cursor = document.querySelector('.typed-cursor') as HTMLElement;
+          if (cursor) cursor.style.display = 'none';
+          if (onTypingComplete !== undefined) onTypingComplete();
+        },
+      });
 
-  const contentScene3 = (
-    <>
-      <div className='pl-2'>
-        <p>Chapter 1</p>
-        <p>"What's two plus two?"</p>
-        <p>Something about the question irritates me. I'm tired. I drift back to sleep.</p>
+      return () => {
+        typed.destroy();
+      };
+    }
+  }, [onTypingComplete, sceneCurrent, typingSpeed, useTypingAnimation]);
 
-        <p>A few minutes pass, then I hear it again.</p>
-        <p>"What's two plus two?"</p>
-        <p>
-          The soft, feminine voice lacks emotion and the pronunciation is identical to the previous
-          time she said it. It's a computer. A computer is hassling me. I'm even more irritated now.
-        </p>
-        <p>
-          "Lrmln," I say. I'm surprised. I meant to say "Leave me alone"—a completely reasonable
-          response in my opinion—but I failed to speak.
-        </p>
-        <p>"Incorrect," says the computer. "What's two plus two?"</p>
-      </div>
+  // REFACTOR: add shot number
+  function getContent(sceneStart: number, sceneEnd: number, sceneCurrent: number): React.ReactNode {
+    const content = [...contentScenes];
+    content[sceneCurrent] = <SceneMarker className='pl-2'>{content[sceneCurrent]}</SceneMarker>;
 
-      <SceneMarker className='pl-2'>
-        <p>Time for an experiment. I'll try to say hello.</p>
-        <p>"Hlllch?" I say.</p>
-        <p>"Incorrect. What's two plus two?"</p>
-        <p>
-          What's going on? I want to find out, but I don't have much to work with. I can't see. I
-          can't hear anything other than the computer. I can't even feel. No, that's not true. I
-          feel something. I'm lying down. I'm on something soft. A bed.
-        </p>
-      </SceneMarker>
-    </>
-  );
+    const chapter = [content[0]];
+    const pageContent = content.slice(sceneStart, sceneEnd + 1);
 
-  let content: React.ReactElement;
-  switch (sceneNum) {
+    return <>{chapter.concat(pageContent)}</>;
+  }
+
+  let content: React.ReactNode;
+  switch (sceneCurrent) {
     case 0:
-      content = contentScene1;
+      content = <div className='pl-2'>{contentIntro}</div>;
       break;
     case 1:
-      content = contentScene1;
+      content = getContent(sceneStart, sceneEnd, sceneCurrent);
       break;
     case 2:
-      content = contentScene1and2;
+      content = getContent(sceneStart, sceneEnd, sceneCurrent);
+      break;
+    case 3:
+      content = getContent(sceneStart, sceneEnd, sceneCurrent);
       break;
     default:
-      content = contentScene3;
+      content = <div />;
+      console.error('scene not available');
   }
 
   return (

--- a/src/components/Book/Page.tsx
+++ b/src/components/Book/Page.tsx
@@ -49,6 +49,7 @@ export default function Page(props: Props) {
 
   // HACK: Had to use &nbsp instead of using css to text-indent due to limitation of typed.js
   // OPTIMIZE: make typing animation work for any page content
+  // OPTIMIZE: move content into data file / firebase
   const contentScene1Typed = (
     <span>
       &nbsp;What's two plus two?

--- a/src/components/Book/Page.tsx
+++ b/src/components/Book/Page.tsx
@@ -51,7 +51,7 @@ export default function Page(props: Props) {
   // OPTIMIZE: make typing animation work for any page content
   const contentScene1Typed = (
     <span>
-      What's two plus two?
+      &nbsp;What's two plus two?
       <br />
       &nbsp;&nbsp;&nbsp;Something about the question irritates me. I'm tired. I drift back to sleep.
       <br />

--- a/src/components/Book/Page.tsx
+++ b/src/components/Book/Page.tsx
@@ -114,14 +114,11 @@ export default function Page(props: Props) {
 
   const contentScene3 = (
     <>
-      {/* REFACTOR: accept the content from a parameter */}
-      <p>Chapter 1</p>
-      <SceneMarker className='pl-2'>
+      <div className='pl-2'>
+        <p>Chapter 1</p>
         <p>"What's two plus two?"</p>
         <p>Something about the question irritates me. I'm tired. I drift back to sleep.</p>
-      </SceneMarker>
 
-      <SceneMarker className='pl-2'>
         <p>A few minutes pass, then I hear it again.</p>
         <p>"What's two plus two?"</p>
         <p>
@@ -133,7 +130,7 @@ export default function Page(props: Props) {
           response in my opinion—but I failed to speak.
         </p>
         <p>"Incorrect," says the computer. "What's two plus two?"</p>
-      </SceneMarker>
+      </div>
 
       <SceneMarker className='pl-2'>
         <p>Time for an experiment. I'll try to say hello.</p>

--- a/src/components/Book/Page.tsx
+++ b/src/components/Book/Page.tsx
@@ -88,20 +88,21 @@ export default function Page(props: Props) {
     </>
   );
 
-  const contentScene2 = (
+  const contentScene1and2 = (
     // REFACTOR: add shot number
     <>
-      <SceneMarker className='pl-2'>
+      <div className='pl-2'>
         <p>"What's two plus two?"</p>
         <p>Something about the question irritates me. I'm tired. I drift back to sleep.</p>
-      </SceneMarker>
-      <SceneMarker className='pl-2'>
         <p>A few minutes pass, then I hear it again.</p>
         <p>"What's two plus two?"</p>
         <p>
           The soft, feminine voice lacks emotion and the pronunciation is identical to the previous
           time she said it. It's a computer. A computer is hassling me. I'm even more irritated now.
         </p>
+      </div>
+
+      <SceneMarker>
         <p>
           "Lrmln," I say. I'm surprised. I meant to say "Leave me alone"—a completely reasonable
           response in my opinion—but I failed to speak.
@@ -155,8 +156,8 @@ export default function Page(props: Props) {
     case 1:
       content = contentScene1;
       break;
-    case 3:
-      content = contentScene2;
+    case 2:
+      content = contentScene1and2;
       break;
     default:
       content = contentScene3;

--- a/src/components/Film/Film.tsx
+++ b/src/components/Film/Film.tsx
@@ -7,19 +7,20 @@ type Props = {
   className?: string;
   onNext: () => void;
   onPrev: () => void;
+  sceneNum: number;
   // REFACTOR: make showPrev showNext on by default. Make it optional to turn off
   showPrev: boolean;
   showNext: boolean;
 };
 
 export default function Film(props: Props) {
-  const { className = '', onNext, onPrev, showPrev, showNext } = props;
+  const { className = '', onNext, onPrev, sceneNum, showPrev, showNext } = props;
 
   return (
     // REFACTOR: move px-2 to global, align with book
     <div className={`mgn-film flex items-center justify-between ${className}`}>
       <PageControl action='prev' onClick={onPrev} className='px-1' isShown={showPrev} />
-      <ScenePanel />
+      <ScenePanel sceneNum={sceneNum} />
       <PageControl action='next' onClick={onNext} className='px-1' isShown={showNext} />
     </div>
   );

--- a/src/components/Film/Film.tsx
+++ b/src/components/Film/Film.tsx
@@ -30,7 +30,8 @@ export default function Film(props: Props) {
         action='next'
         onClick={onNext}
         className='px-1'
-        isShown={!hideNext && scene < 3}
+        // HACK: temporarily make 2, should be 3
+        isShown={!hideNext && scene < 2}
       />
     </div>
   );

--- a/src/components/Film/Film.tsx
+++ b/src/components/Film/Film.tsx
@@ -7,7 +7,7 @@ type Props = {
   className?: string;
   onNext: () => void;
   onPrev: () => void;
-  sceneNum: number;
+  sceneNum: number; // TODO: show PageControls based on first and last scene number
   // REFACTOR: make showPrev showNext on by default. Make it optional to turn off
   showPrev: boolean;
   showNext: boolean;

--- a/src/components/Film/Film.tsx
+++ b/src/components/Film/Film.tsx
@@ -7,20 +7,21 @@ type Props = {
   className?: string;
   onNext: () => void;
   onPrev: () => void;
-  sceneNum: number; // TODO: show PageControls based on first and last scene number
+  scene: number; // TODO: show PageControls based on first and last scene number
   // REFACTOR: make showPrev showNext on by default. Make it optional to turn off
   showPrev: boolean;
   showNext: boolean;
 };
 
 export default function Film(props: Props) {
-  const { className = '', onNext, onPrev, sceneNum, showPrev, showNext } = props;
+  const { className = '', onNext, onPrev, scene, showPrev, showNext } = props;
+
 
   return (
     // REFACTOR: move px-2 to global, align with book
     <div className={`mgn-film flex items-center justify-between ${className}`}>
       <PageControl action='prev' onClick={onPrev} className='px-1' isShown={showPrev} />
-      <ScenePanel sceneNum={sceneNum} />
+      <ScenePanel scene={scene} />
       <PageControl action='next' onClick={onNext} className='px-1' isShown={showNext} />
     </div>
   );

--- a/src/components/Film/Film.tsx
+++ b/src/components/Film/Film.tsx
@@ -9,20 +9,29 @@ type Props = {
   onPrev: () => void;
   scene: number; // TODO: show PageControls based on first and last scene number
   // REFACTOR: make showPrev showNext on by default. Make it optional to turn off
-  showPrev: boolean;
-  showNext: boolean;
+  hideNext?: boolean;
+  hidePrev?: boolean;
 };
 
 export default function Film(props: Props) {
-  const { className = '', onNext, onPrev, scene, showPrev, showNext } = props;
-
+  const { className = '', hideNext = false, hidePrev = false, onNext, onPrev, scene } = props;
 
   return (
     // REFACTOR: move px-2 to global, align with book
     <div className={`mgn-film flex items-center justify-between ${className}`}>
-      <PageControl action='prev' onClick={onPrev} className='px-1' isShown={showPrev} />
+      <PageControl
+        action='prev'
+        onClick={onPrev}
+        className='px-1'
+        isShown={!hidePrev && scene > 0}
+      />
       <ScenePanel scene={scene} />
-      <PageControl action='next' onClick={onNext} className='px-1' isShown={showNext} />
+      <PageControl
+        action='next'
+        onClick={onNext}
+        className='px-1'
+        isShown={!hideNext && scene < 3}
+      />
     </div>
   );
 }

--- a/src/components/Film/Film.tsx
+++ b/src/components/Film/Film.tsx
@@ -23,7 +23,7 @@ export default function Film(props: Props) {
         action='prev'
         onClick={onPrev}
         className='px-1'
-        isShown={!hidePrev && scene > 0}
+        isShown={!hidePrev && scene > 1}
       />
       <ScenePanel scene={scene} />
       <PageControl

--- a/src/components/Film/ScenePanel.tsx
+++ b/src/components/Film/ScenePanel.tsx
@@ -13,6 +13,21 @@ type Props = {
 
 export default function ScenePanel(props: Props) {
   const { className = '', sceneNum } = props;
+  let src = '';
+  let alt = '';
+
+  switch (sceneNum) {
+    case 1:
+      src = '/assets/common/images/storyboard-panel-1.webp';
+      alt =
+        'An overhead, close up shot of a tired person lying down, head falling asleep with eyes slightly open and irritated in a very dark room.';
+      break;
+    case 2:
+      src = '/assets/common/images/storyboard-panel-2.webp';
+      alt = 'close up, head shot person trying to talk';
+      break;
+    default:
+  }
 
   return (
     <div className={`mgn-scenepanel outline rounded-lg p-1 mb-2 w-full ${className}`}>
@@ -25,8 +40,8 @@ export default function ScenePanel(props: Props) {
         {/* OPTIMIZE: load image cdn */}
         {/* OPTIMIZE: create SceneImage component, accept alt and src props */}
         <Image
-          src='/assets/common/images/storyboard-panel-1.webp'
-          alt='An overhead, close up shot of a tired person lying down, head falling asleep with eyes slightly open and irritated in a very dark room.'
+          src={src}
+          alt={alt}
           className='w-auto h-auto mx-auto !object-scale-down'
           width={330}
           height={270}

--- a/src/components/Film/ScenePanel.tsx
+++ b/src/components/Film/ScenePanel.tsx
@@ -42,7 +42,7 @@ export default function ScenePanel(props: Props) {
         <Image
           src={src}
           alt={alt}
-          className='w-auto h-auto mx-auto !object-scale-down'
+          className='w-auto h-auto pl-2 mx-auto !object-scale-down'
           width={330}
           height={270}
         />

--- a/src/components/Film/ScenePanel.tsx
+++ b/src/components/Film/ScenePanel.tsx
@@ -21,7 +21,7 @@ export default function ScenePanel(props: Props) {
         {locale.film.scene}: {sceneNum}
       </div>
       <hr className='border-1 border-black my-1 py-1' />
-      <SceneMarker sceneNum={sceneNum}>
+      <SceneMarker>
         {/* OPTIMIZE: load image cdn */}
         {/* OPTIMIZE: create SceneImage component, accept alt and src props */}
         <Image

--- a/src/components/Film/ScenePanel.tsx
+++ b/src/components/Film/ScenePanel.tsx
@@ -8,15 +8,15 @@ import locale from '@/locales/en.json';
 
 type Props = {
   className?: string;
-  sceneNum: number;
+  scene: number;
 };
 
 export default function ScenePanel(props: Props) {
-  const { className = '', sceneNum } = props;
+  const { className = '', scene } = props;
   let src = '';
   let alt = '';
 
-  switch (sceneNum) {
+  switch (scene) {
     case 1:
       src = '/assets/common/images/storyboard-panel-1.webp';
       alt =
@@ -33,7 +33,7 @@ export default function ScenePanel(props: Props) {
     <div className={`mgn-scenepanel outline rounded-lg p-1 mb-2 w-full ${className}`}>
       {/* OPTIMIZE: find better font */}
       <div className='text-2xs'>
-        {locale.film.scene}: {sceneNum}
+        {locale.film.scene}: {scene}
       </div>
       <hr className='border-1 border-black my-1 py-1' />
       <SceneMarker>

--- a/src/components/Film/ScenePanel.tsx
+++ b/src/components/Film/ScenePanel.tsx
@@ -8,11 +8,11 @@ import locale from '@/locales/en.json';
 
 type Props = {
   className?: string;
+  sceneNum: number;
 };
 
 export default function ScenePanel(props: Props) {
-  const { className = '' } = props;
-  const sceneNum = 1;
+  const { className = '', sceneNum } = props;
 
   return (
     <div className={`mgn-scenepanel outline rounded-lg p-1 mb-2 w-full ${className}`}>

--- a/src/components/SceneMarker/SceneMarker.module.scss
+++ b/src/components/SceneMarker/SceneMarker.module.scss
@@ -1,8 +1,12 @@
 // Copyright rigélblu inc.
 // All rights reserved.
 
-.mgn-scenemarker {
-  p {
-    @apply mb-[0.1rem] indent-3.5;
-  }
+.mgn-scenemarker::before {
+  @apply bg-blue-rb-600;
+
+  content: '';
+  position: absolute;
+  width: 2px;
+  top: 0;
+  bottom: 0;
 }

--- a/src/components/SceneMarker/SceneMarker.module.scss
+++ b/src/components/SceneMarker/SceneMarker.module.scss
@@ -5,21 +5,4 @@
   p {
     @apply mb-[0.1rem] indent-3.5;
   }
-
-  // FIXME: make colors pass contrast accessibility
-  &-blue {
-    border-left: solid blue;
-  }
-
-  &-green {
-    border-left: dotted green;
-  }
-
-  &-orange {
-    border-left: dashed orange;
-  }
-
-  &-black {
-    border-left: solid black;
-  }
 }

--- a/src/components/SceneMarker/SceneMarker.tsx
+++ b/src/components/SceneMarker/SceneMarker.tsx
@@ -3,19 +3,13 @@
 import styles from './SceneMarker.module.scss';
 
 type Props = {
-  className?: string;
   children: React.ReactNode;
+  className?: string;
 };
 
 // REFACTOR: rename to SceneIndicator
 export default function SceneMarker(props: Props) {
   const { children, className = '' } = props;
 
-  return (
-    <div
-      className={`${styles['mgn-scenemarker']} pl-1 border-l-2 border-l-blue-rb-600 ${className}`}
-    >
-      {children}
-    </div>
-  );
+  return <div className={`${styles['mgn-scenemarker']} relative ${className}`}>{children}</div>;
 }

--- a/src/components/SceneMarker/SceneMarker.tsx
+++ b/src/components/SceneMarker/SceneMarker.tsx
@@ -13,7 +13,7 @@ export default function SceneMarker(props: Props) {
 
   return (
     <div
-      className={`${styles['mgn-scenemarker']} my-1 border-left-2 border-l-blue-rb-600 ${className}`}
+      className={`${styles['mgn-scenemarker']} pl-1 border-l-2 border-l-blue-rb-600 ${className}`}
     >
       {children}
     </div>

--- a/src/components/SceneMarker/SceneMarker.tsx
+++ b/src/components/SceneMarker/SceneMarker.tsx
@@ -2,36 +2,19 @@
 // All rights reserved.
 import styles from './SceneMarker.module.scss';
 
-interface Props {
-  children: React.ReactNode;
-  sceneNum: number;
+type Props = {
   className?: string;
-}
+  children: React.ReactNode;
+};
 
 // REFACTOR: rename to SceneIndicator
 export default function SceneMarker(props: Props) {
-  const { children, sceneNum, className = '' } = props;
-  console.log('sceneNum', JSON.stringify(sceneNum, null, 2));
+  const { children, className = '' } = props;
 
-  // OPTIMIZE: keep track how many scenes there are with state, don't make a requirement to pass in
-  let sceneColor = '';
-  switch (sceneNum) {
-    case 1:
-      sceneColor = styles['scene-blue'];
-      break;
-    case 2:
-      sceneColor = styles['scene-orange'];
-      break;
-    case 3:
-      sceneColor = styles['scene-green'];
-      break;
-    default:
-      sceneColor = styles['scene-black'];
-  }
-
-  // TODO: make scene accessible
   return (
-    <div className={`${styles['mgn-scenemarker']} my-1 border-left-2 ${sceneColor} ${className}`}>
+    <div
+      className={`${styles['mgn-scenemarker']} my-1 border-left-2 border-l-blue-rb-600 ${className}`}
+    >
       {children}
     </div>
   );

--- a/src/pages/try-magin/2/index.tsx
+++ b/src/pages/try-magin/2/index.tsx
@@ -16,7 +16,7 @@ import locale from '@/locales/en.json';
 export default function MarginPreview() {
   const router = useRouter();
   const [isBookDisplayed, setBookDisplayed] = useState(false);
-  const [sceneNum, setSceneNum] = useState(2);
+  const [sceneNum, setSceneNum] = useState(0);
 
   return (
     <MainLayout canvasClassName='bg-black' className='mgn-try-magin bg-white' layoutKind='app'>
@@ -36,7 +36,7 @@ export default function MarginPreview() {
           <div className='mgn-step-middle flex flex-col items-center'>
             {/* REFACTOR: make content an optional parameter */}
             {/* REFACTOR: make this cleaner */}
-            {!isBookDisplayed && sceneNum === 1 && (
+            {!isBookDisplayed && sceneNum === 0 && (
               <>
                 <IconUpArrow className='w-16' />
                 <GuideMessage className='font-bold'>
@@ -45,7 +45,7 @@ export default function MarginPreview() {
                 </GuideMessage>
               </>
             )}
-            {isBookDisplayed && sceneNum === 1 && (
+            {isBookDisplayed && sceneNum === 0 && (
               <>
                 <IconUpArrow className='w-16' />
                 <GuideMessage
@@ -55,7 +55,7 @@ export default function MarginPreview() {
                 />
               </>
             )}
-            {isBookDisplayed && sceneNum !== 1 && (
+            {isBookDisplayed && sceneNum !== 0 && (
               <GuideMessage
                 className='font-bold'
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -67,7 +67,7 @@ export default function MarginPreview() {
           <div className='mgn-step-bottom flex flex-1 items-center'>
             {/* TODO: show on a 5 second delay */}
             {/* OPTIMIZE: figure out how to allow \n in the string and convert in to <br /> */}
-            {isBookDisplayed && sceneNum === 1 && (
+            {isBookDisplayed && sceneNum === 0 && (
               <div className='flex flex-col items-center animate-fadeIn'>
                 <Image
                   src='/assets/common/images/movie-screen.webp'
@@ -78,7 +78,7 @@ export default function MarginPreview() {
                 />
               </div>
             )}
-            {isBookDisplayed && sceneNum !== 1 && (
+            {isBookDisplayed && sceneNum !== 0 && (
               <div className='mgn-step-bottom max-h-for-screen flex flex-1 items-center animate-fadeIn'>
                 <Film
                   className='flex-1'
@@ -86,6 +86,7 @@ export default function MarginPreview() {
                     router.push('/try-magin/3');
                   }}
                   onPrev={() => {}}
+                  sceneNum={sceneNum}
                   showPrev={false}
                   showNext
                 />
@@ -94,7 +95,7 @@ export default function MarginPreview() {
           </div>
 
           {/* REFACTOR: make this cleaner */}
-          {isBookDisplayed && sceneNum === 1 && (
+          {isBookDisplayed && sceneNum === 0 && (
             <Navigation
               left={{
                 className: 'mgn-cta-secondary',
@@ -113,7 +114,7 @@ export default function MarginPreview() {
               }}
             />
           )}
-          {isBookDisplayed && sceneNum !== 1 && (
+          {isBookDisplayed && sceneNum !== 0 && (
             <Navigation
               left={{
                 className: 'mgn-cta-secondary',

--- a/src/pages/try-magin/2/index.tsx
+++ b/src/pages/try-magin/2/index.tsx
@@ -16,7 +16,7 @@ import locale from '@/locales/en.json';
 export default function MarginPreview() {
   const router = useRouter();
   const [isBookDisplayed, setBookDisplayed] = useState(false);
-  const [sceneNum, setSceneNum] = useState(0);
+  const [scene, setScene] = useState(0);
 
   return (
     <MainLayout canvasClassName='bg-black' className='mgn-try-magin bg-white' layoutKind='app'>
@@ -28,7 +28,7 @@ export default function MarginPreview() {
           <div className='mgn-step-top col flex flex-col justify-start h-[30rem]'>
             <Book
               onTypingComplete={() => setBookDisplayed(true)}
-              sceneNum={sceneNum}
+              scene={scene}
               useTypingAnimation={!isBookDisplayed}
             />
           </div>
@@ -36,7 +36,7 @@ export default function MarginPreview() {
           <div className='mgn-step-middle flex flex-col items-center'>
             {/* REFACTOR: make content an optional parameter */}
             {/* REFACTOR: make this cleaner */}
-            {!isBookDisplayed && sceneNum === 0 && (
+            {!isBookDisplayed && scene === 0 && (
               <>
                 <IconUpArrow className='w-16' />
                 <GuideMessage className='font-bold'>
@@ -45,7 +45,7 @@ export default function MarginPreview() {
                 </GuideMessage>
               </>
             )}
-            {isBookDisplayed && sceneNum === 0 && (
+            {isBookDisplayed && scene === 0 && (
               <>
                 <IconUpArrow className='w-16' />
                 <GuideMessage
@@ -55,7 +55,7 @@ export default function MarginPreview() {
                 />
               </>
             )}
-            {isBookDisplayed && sceneNum !== 0 && (
+            {isBookDisplayed && scene !== 0 && (
               <GuideMessage
                 className='font-bold'
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -67,7 +67,7 @@ export default function MarginPreview() {
           <div className='mgn-step-bottom flex flex-1 items-center'>
             {/* TODO: show on a 5 second delay */}
             {/* OPTIMIZE: figure out how to allow \n in the string and convert in to <br /> */}
-            {isBookDisplayed && sceneNum === 0 && (
+            {isBookDisplayed && scene === 0 && (
               <div className='flex flex-col items-center animate-fadeIn'>
                 <Image
                   src='/assets/common/images/movie-screen.webp'
@@ -78,7 +78,7 @@ export default function MarginPreview() {
                 />
               </div>
             )}
-            {isBookDisplayed && sceneNum !== 0 && (
+            {isBookDisplayed && scene !== 0 && (
               <div className='mgn-step-bottom max-h-for-screen flex flex-1 items-center animate-fadeIn'>
                 <Film
                   className='flex-1'
@@ -86,7 +86,7 @@ export default function MarginPreview() {
                     router.push('/try-magin/3');
                   }}
                   onPrev={() => {}}
-                  sceneNum={sceneNum}
+                  scene={scene}
                   showPrev={false}
                   showNext
                 />
@@ -95,7 +95,7 @@ export default function MarginPreview() {
           </div>
 
           {/* REFACTOR: make this cleaner */}
-          {isBookDisplayed && sceneNum === 0 && (
+          {isBookDisplayed && scene === 0 && (
             <Navigation
               left={{
                 className: 'mgn-cta-secondary',
@@ -109,12 +109,12 @@ export default function MarginPreview() {
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                 label: locale.guide.tryMagin2a_showMe,
                 onClick: () => {
-                  setSceneNum(sceneNum + 1);
+                  setScene(scene + 1);
                 },
               }}
             />
           )}
-          {isBookDisplayed && sceneNum !== 0 && (
+          {isBookDisplayed && scene !== 0 && (
             <Navigation
               left={{
                 className: 'mgn-cta-secondary',

--- a/src/pages/try-magin/2/index.tsx
+++ b/src/pages/try-magin/2/index.tsx
@@ -16,7 +16,7 @@ import locale from '@/locales/en.json';
 export default function MarginPreview() {
   const router = useRouter();
   const [isBookDisplayed, setBookDisplayed] = useState(false);
-  const [onNextScene, setNextScene] = useState(false);
+  const [sceneNum, setSceneNum] = useState(2);
 
   return (
     <MainLayout canvasClassName='bg-black' className='mgn-try-magin bg-white' layoutKind='app'>
@@ -36,7 +36,7 @@ export default function MarginPreview() {
           <div className='mgn-step-middle flex flex-col items-center'>
             {/* REFACTOR: make content an optional parameter */}
             {/* REFACTOR: make this cleaner */}
-            {!isBookDisplayed && !onNextScene && (
+            {!isBookDisplayed && sceneNum === 1 && (
               <>
                 <IconUpArrow className='w-16' />
                 <GuideMessage className='font-bold'>
@@ -45,7 +45,7 @@ export default function MarginPreview() {
                 </GuideMessage>
               </>
             )}
-            {isBookDisplayed && !onNextScene && (
+            {isBookDisplayed && sceneNum === 1 && (
               <>
                 <IconUpArrow className='w-16' />
                 <GuideMessage
@@ -55,7 +55,7 @@ export default function MarginPreview() {
                 />
               </>
             )}
-            {isBookDisplayed && onNextScene && (
+            {isBookDisplayed && sceneNum !== 1 && (
               <GuideMessage
                 className='font-bold'
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -67,7 +67,7 @@ export default function MarginPreview() {
           <div className='mgn-step-bottom flex flex-1 items-center'>
             {/* TODO: show on a 5 second delay */}
             {/* OPTIMIZE: figure out how to allow \n in the string and convert in to <br /> */}
-            {isBookDisplayed && !onNextScene && (
+            {isBookDisplayed && sceneNum === 1 && (
               <div className='flex flex-col items-center animate-fadeIn'>
                 <Image
                   src='/assets/common/images/movie-screen.webp'
@@ -78,7 +78,7 @@ export default function MarginPreview() {
                 />
               </div>
             )}
-            {isBookDisplayed && onNextScene && (
+            {isBookDisplayed && sceneNum !== 1 && (
               <div className='mgn-step-bottom max-h-for-screen flex flex-1 items-center animate-fadeIn'>
                 <Film
                   className='flex-1'
@@ -94,7 +94,7 @@ export default function MarginPreview() {
           </div>
 
           {/* REFACTOR: make this cleaner */}
-          {isBookDisplayed && !onNextScene && (
+          {isBookDisplayed && sceneNum === 1 && (
             <Navigation
               left={{
                 className: 'mgn-cta-secondary',
@@ -108,12 +108,12 @@ export default function MarginPreview() {
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                 label: locale.guide.tryMagin2a_showMe,
                 onClick: () => {
-                  setNextScene(true);
+                  setSceneNum(sceneNum + 1);
                 },
               }}
             />
           )}
-          {isBookDisplayed && onNextScene && (
+          {isBookDisplayed && sceneNum !== 1 && (
             <Navigation
               left={{
                 className: 'mgn-cta-secondary',

--- a/src/pages/try-magin/2/index.tsx
+++ b/src/pages/try-magin/2/index.tsx
@@ -27,8 +27,8 @@ export default function MarginPreview() {
           {/* HACK: have to use fixed rem for height due to mobile browsers */}
           <div className='mgn-step-top col flex flex-col justify-start h-[30rem]'>
             <Book
-              maginPreviewStep={2}
               onTypingComplete={() => setBookDisplayed(true)}
+              sceneNum={sceneNum}
               useTypingAnimation={!isBookDisplayed}
             />
           </div>

--- a/src/pages/try-magin/2/index.tsx
+++ b/src/pages/try-magin/2/index.tsx
@@ -17,6 +17,8 @@ export default function MarginPreview() {
   const router = useRouter();
   const [isBookDisplayed, setBookDisplayed] = useState(false);
   const [scene, setScene] = useState(0);
+  const startScene = 1;
+  const endScene = 1;
 
   return (
     <MainLayout canvasClassName='bg-black' className='mgn-try-magin bg-white' layoutKind='app'>
@@ -28,7 +30,9 @@ export default function MarginPreview() {
           <div className='mgn-step-top col flex flex-col justify-start h-[30rem]'>
             <Book
               onTypingComplete={() => setBookDisplayed(true)}
-              scene={scene}
+              sceneCurrent={scene}
+              sceneEnd={endScene}
+              sceneStart={startScene}
               useTypingAnimation={!isBookDisplayed}
             />
           </div>

--- a/src/pages/try-magin/2/index.tsx
+++ b/src/pages/try-magin/2/index.tsx
@@ -87,8 +87,6 @@ export default function MarginPreview() {
                   }}
                   onPrev={() => {}}
                   scene={scene}
-                  showPrev={false}
-                  showNext
                 />
               </div>
             )}

--- a/src/pages/try-magin/3/index.tsx
+++ b/src/pages/try-magin/3/index.tsx
@@ -1,7 +1,7 @@
 // Copyright rigélblu inc.
 // All rigts reserve
 import { useRouter } from 'next/router';
-
+import { useState } from 'react';
 import Book from '@/components/Book/Book';
 import Film from '@/components/Film/Film';
 import GuideMessage from '@/components/GuideMessage';
@@ -15,6 +15,9 @@ import styles from '../try-magin.module.scss';
 
 export default function MarginPreview() {
   const router = useRouter();
+  const [scene, setScene] = useState(2);
+  const startScene = 1;
+  const endScene = 2;
 
   return (
     <MainLayout canvasClassName='bg-black' className='mgn-try-magin bg-white' layoutKind='app'>
@@ -26,7 +29,12 @@ export default function MarginPreview() {
         <div className='mgn-step flex	w-full flex-1 flex-col justify-between bg-yellow-rb-200 sm:max-h-[51rem] sm:max-w-[25rem] p-2'>
           {/* HACK: have to use fixed rem for height due to mobile browsers */}
           <div className='mgn-step-top col max-h-for-screen flex flex-col justify-start h-[30rem]'>
-            <Book maginPreviewStep={3} className='flex-1 overflow-hidden' />
+            <Book
+              className='flex-1 overflow-hidden'
+              sceneCurrent={scene}
+              sceneEnd={endScene}
+              sceneStart={startScene}
+            />
           </div>
 
           <div className='mgn-step-middle'>
@@ -40,11 +48,12 @@ export default function MarginPreview() {
             <Film
               className='flex-1'
               onNext={() => {
-                router.push('/try-magin/3');
+                setScene(scene + 1);
               }}
-              onPrev={() => {}}
-              showPrev
-              showNext
+              onPrev={() => {
+                setScene(scene - 1);
+              }}
+              scene={scene}
             />
           </div>
 
@@ -63,7 +72,7 @@ export default function MarginPreview() {
               // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
               label: locale.guide.tryMagin3a_nextScene,
               onClick: () => {
-                router.push('/join/1');
+                setScene(scene + 1);
               },
             }}
           />

--- a/src/pages/try-magin/3/index.tsx
+++ b/src/pages/try-magin/3/index.tsx
@@ -58,7 +58,6 @@ export default function MarginPreview() {
           </div>
 
           {/* HACK: temporarily disable */}
-
           <Navigation
             left={{
               className: 'mgn-cta-secondary',

--- a/src/pages/try-magin/3/index.tsx
+++ b/src/pages/try-magin/3/index.tsx
@@ -58,23 +58,25 @@ export default function MarginPreview() {
           </div>
 
           {/* HACK: temporarily disable */}
-          <Navigation
-            left={{
-              className: 'mgn-cta-secondary',
-              label: locale.navigation.back,
-              onClick: () => {
-                router.push('/try-magin/2');
-              },
-            }}
-            right={{
-              className: 'mgn-cta-primary',
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-              label: locale.guide.tryMagin3a_nextScene,
-              onClick: () => {
-                setScene(scene + 1);
-              },
-            }}
-          />
+          {false && (
+            <Navigation
+              left={{
+                className: 'mgn-cta-secondary',
+                label: locale.navigation.back,
+                onClick: () => {
+                  router.push('/try-magin/2');
+                },
+              }}
+              right={{
+                className: 'mgn-cta-primary',
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                label: locale.guide.tryMagin3a_nextScene,
+                onClick: () => {
+                  setScene(scene + 1);
+                },
+              }}
+            />
+          )}
         </div>
       </div>
     </MainLayout>

--- a/src/pages/try-magin/3/index.tsx
+++ b/src/pages/try-magin/3/index.tsx
@@ -44,7 +44,7 @@ export default function MarginPreview() {
             <GuideMessage className='font-bold' messages={locale.guide.tryMagin3a_guidedMessage} />
           </div>
 
-          <div className='mgn-step-bottom max-h-for-screen flex flex-1 items-center animate-fadeIn'>
+          <div className='mgn-step-bottom max-h-for-screen flex flex-1 items-center animate-delayFadeIn'>
             <Film
               className='flex-1'
               onNext={() => {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -18,6 +18,7 @@ module.exports = {
     extend: {
       animation: {
         fadeIn: 'fadeIn ease-in 1s',
+        delayFadeIn: 'fadeIn ease-in 4s',
       },
       colors: {
         'blue-rb-100': '#f4faff',
@@ -28,6 +29,11 @@ module.exports = {
       fontFamily: { theano: ['Theano Old Style'] },
       fontSize: { xs: '0.875rem', '2xs': '0.75rem' },
       keyframes: {
+        delayFadeIn: {
+          '0%': { opacity: 0 },
+          '6%': { opacity: 0 },
+          '100%': { opacity: 1 },
+        },
         fadeIn: {
           '0%': { opacity: 0 },
           '100%': { opacity: 1 },


### PR DESCRIPTION
# What changed - describe what changes you made

- refactor | use sceneNum to switch to next scene
- feat | require sceneNum prop in Film and ScenePanel
- refactor | pass sceneNum to film
- refactor | don't pass sceneNum to SceneMarker
- feat | use same scene marker for all scenes
- refactor | use sceneNum to display page content
- fix | scene marker doesn't show on film or book
- fix | misaligned text when below scene has scene marker
- style : add a optimize reminder
- feat | remove scene marker from scene 1
- feat | show scene marker only on active scene
- feat | show scene marker only on active scene
- feat | show image based on sceneNum
- refactor | rename sceneNum to scene
- feat | show pageControls by default, make hiding optional
- fix | pageControl isn't hidden on first scene
- feat | display page based on start, end, and current scene passed as props
- feat | use page controls on try-magin/3
- feat | show nav
- feat | delay image appearing
- fix | special css for p in page isn't applied to all content
- fix | padding isn't consistent across scenes
- fix | border is shifting content
- feat | temporarily disable going to 3rd scene