### PR TITLE
feat | show cue on CTAs

### DIFF
--- a/src/components/Cue.tsx
+++ b/src/components/Cue.tsx
@@ -1,0 +1,28 @@
+// Copyright rigélblu inc.
+// All rights reserved.
+import React from 'react';
+
+type Props = {
+  className?: string;
+  children?: React.ReactNode;
+};
+
+export default function Cue(props: Props) {
+  const { className = '', children = undefined } = props;
+
+  return (
+    <div className={`${className}`}>
+      {React.Children.map(children, (child) => {
+        // Verify that the child is a valid React element
+        if (!React.isValidElement(child)) return child;
+
+        // Add the `animate-shadow` class to the child's existing classes
+        return React.cloneElement(child, {
+          // @ts-expect-error FIXME: later
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions, @typescript-eslint/no-unsafe-member-access
+          className: `animate-shadow ${child.props.className || ''}`,
+        });
+      })}
+    </div>
+  );
+}

--- a/src/components/Film/ScenePanel.tsx
+++ b/src/components/Film/ScenePanel.tsx
@@ -43,7 +43,7 @@ export default function ScenePanel(props: Props) {
 
       <hr className='border-1 my-1 border-black' />
 
-      <SceneMarker className='my-1 flex flex-1 flex-col content-center '>
+      <SceneMarker className='my-1 flex flex-1 flex-col content-center'>
         {/* OPTIMIZE: load image cdn */}
         {/* OPTIMIZE: create SceneImage component, accept alt and src props */}
         <Image src={img.src} alt={img.alt} className='!w-min object-scale-down pl-2' fill />

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -3,12 +3,12 @@
 import { Button } from 'primereact/button';
 
 // REFACTOR: accept enums  for className and translate to proper css class
-interface Props {
+type Props = {
   left?: { className: string; label: string; onClick: () => void };
   middle?: { className: string; label: string; onClick: () => void };
   right?: { className: string; label: string; onClick: () => void };
   className?: string;
-}
+};
 
 export default function Navigation(props: Props) {
   const { left = null, middle = null, right = null, className = '' } = props;

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -1,6 +1,7 @@
 // Copyright rigélblu inc.
 // All rights reserved.
 import { Button } from 'primereact/button';
+import Cue from '@/components/Cue';
 
 // REFACTOR: accept enums  for className and translate to proper css class
 type Props = {
@@ -27,9 +28,12 @@ export default function Navigation(props: Props) {
         </Button>
       )}
       {right && (
-        <Button className={`text-center ${right.className}`} onClick={right.onClick}>
-          {right.label}
-        </Button>
+        // OPTIMIZE: make it optional based on prop
+        <Cue>
+          <Button className={`text-center ${right.className}`} onClick={right.onClick}>
+            {right.label}
+          </Button>
+        </Cue>
       )}
     </div>
   );

--- a/src/components/PageControl/PageControl.tsx
+++ b/src/components/PageControl/PageControl.tsx
@@ -25,6 +25,7 @@ export default function PageControl(props: Props) {
       onClick={onClick}
     >
       {!isShown && <span className='w-3' />}
+      {/* OPTIMIZE: animate-shadow creates a not so good look. Duplicate svg and show it */}
       {isShown && action === 'prev' && <IconArrowLeft className='w-3' />}
       {isShown && action === 'next' && <IconArrowRight className='w-3' />}
     </Button>

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -2,6 +2,20 @@
  * All rights reserved. */
 
 @tailwind base;
+@tailwind components;
 @tailwind utilities;
 
-/* @tailwind components; */
+@layer components {
+  .animate-shadow {
+    animation: shadow-pulse 2s cubic-bezier(0.4, 0, 0.2, 1) 2s forwards;
+  }
+
+  @keyframes shadow-pulse {
+    0% {
+      box-shadow: 0 0 #0000;
+    }
+    100% {
+      box-shadow: 0 4px 14px 0 #0080ff, 0 6px 20px 0 #0080ff; /* color: blue-rb */
+    }
+  }
+}

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -1,9 +1,5 @@
-/*
- * Copyright rigélblu inc.
- * All rights reserved.
- */
-
-/* TODO: determine if we'll use the compponent styles */
+/* Copyright rigélblu inc.
+ * All rights reserved. */
 
 @tailwind base;
 @tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -23,7 +23,11 @@ module.exports = {
       colors: {
         'blue-rb-100': '#f4faff',
         'blue-rb-400': '#e4f2ff',
+        'blue-rb-500': '#a7d9ff',
         'blue-rb-600': '#0080ff',
+        'blue-rb-700': '#0054a8',
+        'blue-rb-800': '#0e4f8f',
+        'blue-rb-900': '#104070',
         'yellow-rb-200': '#faf8f4',
       },
       fontFamily: { theano: ['Theano Old Style'] },


### PR DESCRIPTION
# What changed - describe what changes you made

- feat | add blue-rb variants
- style | comments
- feat | private Cue component that animates a shadow
- style: whitespace
- refactor | convert interface to props
- style | comment
- feat | show cue on primary cta in navigation
